### PR TITLE
new cmake stuff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 # de-duplicate linker inputs
 cmake_policy(SET CMP0156 NEW)
@@ -131,26 +131,13 @@ include_directories(
 # Add project subdirectories
 add_subdirectory(src)
 
-list(APPEND m_targets
-    block_buffer
-    byte_streams
-    cast
-    command_options
-    csv
-    filesystem
-    io
-    math
-    memory
-    pe
-    strings
-    tracing
-    utf
-    errors
-    multi_byte
+list(APPEND m_installation_targets
     pe2csv
     pe2l
 )
 
 install(
-    TARGETS ${m_targets}
+    TARGETS ${m_installation_targets}
+    FILE_SET HEADERS
+#        DESTINATION ${M_INSTALL_INCLUDEDIR}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 add_subdirectory(include)
 add_subdirectory(libraries)
@@ -11,3 +11,5 @@ endif()
 if(LINUX)
     add_subdirectory(Linux)
 endif()
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/Linux/CMakeLists.txt
+++ b/src/Linux/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 #add_subdirectory(include)
 #add_subdirectory(libraries)
 #add_subdirectory(tools)
 
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/Windows/CMakeLists.txt
+++ b/src/Windows/CMakeLists.txt
@@ -1,23 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
-
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles([=[
-#include <sdkddkver.h>
-static_assert(WDK_NTDDI_VERSION >= NTDDI_WIN10_NI, "Inspecting WDK_NTDDI_VERSION, the Windows SDK version.");
-int main() {}
-]=] WINDOWS_SDK_VERSION_CHECK)
-
-if(NOT WINDOWS_SDK_VERSION_CHECK)
-    message(FATAL_ERROR "The STL must be built with the Windows 11 SDK (10.0.22621.0) or later. Make sure it's available by selecting it in the Individual Components tab of the VS Installer.")
-endif()
+cmake_minimum_required(VERSION 3.23)
 
 add_compile_definitions(
-    _ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH WIN32_LEAN_AND_MEAN STRICT _CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS
-    _WIN32_WINNT=0x0A00 NTDDI_VERSION=NTDDI_WIN10_NI
+    WIN32_LEAN_AND_MEAN
+    STRICT
+    _WIN32_WINNT=0x0A00
+    NTDDI_VERSION=0x0A000000
     NOMINMAX
 )
 
-#add_subdirectory(include)
 add_subdirectory(libraries)
-#add_subdirectory(tools)
 
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/Windows/libraries/CMakeLists.txt
+++ b/src/Windows/libraries/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 add_subdirectory(errors)
 add_subdirectory(multi_byte)
 
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/Windows/libraries/errors/CMakeLists.txt
+++ b/src/Windows/libraries/errors/CMakeLists.txt
@@ -1,4 +1,12 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_errors STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
+
+list(APPEND m_installation_targets
+    m_errors
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/Windows/libraries/errors/include/CMakeLists.txt
+++ b/src/Windows/libraries/errors/include/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/errors
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_errors PUBLIC FILE_SET HEADERS FILES
+    m/errors/errors.h
+    m/errors/win32_error_code.h
 )

--- a/src/Windows/libraries/errors/src/CMakeLists.txt
+++ b/src/Windows/libraries/errors/src/CMakeLists.txt
@@ -1,17 +1,14 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-add_library(errors STATIC
+target_sources(m_errors PRIVATE
     errors.cpp
     win32_error_code.cpp)
 
-target_include_directories(errors PUBLIC
+target_include_directories(m_errors PUBLIC
     ../include
 )
 
-target_link_libraries(errors PUBLIC
+target_link_libraries(m_errors PUBLIC
 )
 
-set_target_properties(errors PROPERTIES
-    VERSION ${VERSION}
-)
-
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/Windows/libraries/multi_byte/CMakeLists.txt
+++ b/src/Windows/libraries/multi_byte/CMakeLists.txt
@@ -1,5 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_multi_byte STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(test)
+
+list(APPEND m_installation_targets
+    m_multi_byte
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/Windows/libraries/multi_byte/include/CMakeLists.txt
+++ b/src/Windows/libraries/multi_byte/include/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/multi_byte
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_multi_byte PUBLIC FILE_SET HEADERS FILES
+    m/multi_byte/code_page.h
+    m/multi_byte/multi_byte.h
 )

--- a/src/Windows/libraries/multi_byte/src/CMakeLists.txt
+++ b/src/Windows/libraries/multi_byte/src/CMakeLists.txt
@@ -1,19 +1,20 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-add_library(multi_byte STATIC
-    "multi_byte_to_utf16.cpp"
-  "utf16_to_multi_byte.cpp")
+target_sources(m_multi_byte PRIVATE
+    multi_byte_to_utf16.cpp
+    utf16_to_multi_byte.cpp)
 
-target_include_directories(multi_byte PUBLIC
+target_include_directories(m_multi_byte PUBLIC
     ../include
 )
 
-target_link_libraries(multi_byte PUBLIC
-    errors
-    math
+target_link_libraries(m_multi_byte PUBLIC
+    m_errors
+    m_math
 )
 
-set_target_properties(multi_byte PROPERTIES
-    VERSION ${VERSION}
+list(APPEND m_installation_targets
+    m_multi_byte
 )
 
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/Windows/libraries/multi_byte/test/CMakeLists.txt
+++ b/src/Windows/libraries/multi_byte/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 if(M_BUILD_TESTS)
     include(GoogleTest)
@@ -10,10 +10,10 @@ if(M_BUILD_TESTS)
 
     target_link_libraries(
       test_multi_byte
-      cast
-      multi_byte
-      strings
-      math
+      m_cast
+      m_multi_byte
+      m_strings
+      m_math
       GTest::gtest_main
     )
 

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 add_subdirectory(m)

--- a/src/include/m/CMakeLists.txt
+++ b/src/include/m/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 # Produce the final version.h using template version.h.in and substituting variables.
 # We don't want to polute our source tree with it, thus putting it in binary tree.

--- a/src/libraries/CMakeLists.txt
+++ b/src/libraries/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 add_subdirectory(block_buffer)
 add_subdirectory(byte_streams)
@@ -14,3 +14,4 @@ add_subdirectory(strings)
 add_subdirectory(tracing)
 add_subdirectory(utf)
 
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/block_buffer/CMakeLists.txt
+++ b/src/libraries/block_buffer/CMakeLists.txt
@@ -1,4 +1,12 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_block_buffer STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
+
+list(APPEND m_installation_targets
+    m_block_buffer
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/block_buffer/include/CMakeLists.txt
+++ b/src/libraries/block_buffer/include/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/block_buffer
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_block_buffer PUBLIC FILE_SET HEADERS FILES
+    m/block_buffer/block_buffer.h
 )

--- a/src/libraries/block_buffer/src/CMakeLists.txt
+++ b/src/libraries/block_buffer/src/CMakeLists.txt
@@ -1,13 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-add_library(block_buffer STATIC
+target_sources(m_block_buffer PRIVATE
     block_buffer.cpp
 )
 
-target_include_directories(block_buffer PUBLIC
+target_include_directories(m_block_buffer PUBLIC
     ../include
 )
 
-target_link_libraries(block_buffer PUBLIC
-    math
+target_link_libraries(m_block_buffer PUBLIC
+    m_math
 )

--- a/src/libraries/block_buffer/test/CMakeLists.txt
+++ b/src/libraries/block_buffer/test/CMakeLists.txt
@@ -1,3 +1,3 @@
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 

--- a/src/libraries/byte_streams/CMakeLists.txt
+++ b/src/libraries/byte_streams/CMakeLists.txt
@@ -1,4 +1,12 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_byte_streams STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
+
+list(APPEND m_installation_targets
+    m_byte_streams
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/byte_streams/include/CMakeLists.txt
+++ b/src/libraries/byte_streams/include/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/byte_streams
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_byte_streams PUBLIC FILE_SET HEADERS FILES
+    m/byte_streams/byte_streams.h
+    m/byte_streams/memory_based_byte_streams.h
 )

--- a/src/libraries/byte_streams/src/CMakeLists.txt
+++ b/src/libraries/byte_streams/src/CMakeLists.txt
@@ -1,21 +1,16 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-# Define the library
-add_library(byte_streams STATIC
+target_sources(m_byte_streams PRIVATE
     byte_streams.cpp
     memory_stream.cpp
 )
 
-# target_compile_definitions(filesystem PRIVATE _CRT_SECURE_NO_WARNINGS)
-
-target_link_libraries(byte_streams PUBLIC
-#    block_buffer
-    cast
-    io
-    math
-#    memory
+target_link_libraries(m_byte_streams PUBLIC
+    m_cast
+    m_io
+    m_math
 )
 
-target_include_directories(byte_streams PUBLIC
+target_include_directories(m_byte_streams PUBLIC
     ../include
 )

--- a/src/libraries/cast/CMakeLists.txt
+++ b/src/libraries/cast/CMakeLists.txt
@@ -1,5 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_cast STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(test)
+
+list(APPEND m_installation_targets
+    m_cast
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/cast/include/CMakeLists.txt
+++ b/src/libraries/cast/include/CMakeLists.txt
@@ -1,5 +1,7 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/cast
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_cast PUBLIC FILE_SET HEADERS FILES 
+    m/cast/cast.h
+    m/cast/to.h
+    m/cast/try_cast.h
 )

--- a/src/libraries/cast/include/m/cast/CMakeLists.txt
+++ b/src/libraries/cast/include/m/cast/CMakeLists.txt
@@ -1,2 +1,0 @@
-cmake_minimum_required(VERSION 3.22)
-

--- a/src/libraries/cast/src/CMakeLists.txt
+++ b/src/libraries/cast/src/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-add_library(cast STATIC
+target_sources(m_cast PRIVATE
     cast.cpp
 )
 
-target_include_directories(cast PUBLIC
+target_include_directories(m_cast PUBLIC
     ../include
 )

--- a/src/libraries/cast/test/CMakeLists.txt
+++ b/src/libraries/cast/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 if(M_BUILD_TESTS)
     include(GoogleTest)
@@ -12,8 +12,8 @@ if(M_BUILD_TESTS)
 
     target_link_libraries(
       test_cast
-      cast
-      math
+      m_cast
+      m_math
       GTest::gtest_main
     )
 

--- a/src/libraries/command_options/CMakeLists.txt
+++ b/src/libraries/command_options/CMakeLists.txt
@@ -1,5 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_command_options STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(test)
+
+list(APPEND m_installation_targets
+    m_command_options
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/command_options/include/CMakeLists.txt
+++ b/src/libraries/command_options/include/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/command_options
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_command_options PUBLIC FILE_SET HEADERS FILES 
+    m/command_options/command_options.h
 )

--- a/src/libraries/command_options/src/CMakeLists.txt
+++ b/src/libraries/command_options/src/CMakeLists.txt
@@ -1,20 +1,19 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-# Define the library
-add_library(command_options STATIC
+target_sources(m_command_options PRIVATE
     command_options.cpp
 )
 
-target_compile_definitions(command_options PRIVATE _CRT_SECURE_NO_WARNINGS)
+target_compile_definitions(m_command_options PRIVATE _CRT_SECURE_NO_WARNINGS)
 
-target_link_libraries(command_options PUBLIC
-    cast
-    filesystem
-    math
-    memory
-    strings
+target_link_libraries(m_command_options PUBLIC
+    m_cast
+    m_filesystem
+    m_math
+    m_memory
+    m_strings
 )
 
-target_include_directories(command_options PUBLIC
+target_include_directories(m_command_options PUBLIC
     ../include
 )

--- a/src/libraries/command_options/test/CMakeLists.txt
+++ b/src/libraries/command_options/test/CMakeLists.txt
@@ -1,1 +1,1 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)

--- a/src/libraries/csv/CMakeLists.txt
+++ b/src/libraries/csv/CMakeLists.txt
@@ -1,6 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_csv STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(test)
 
+list(APPEND m_installation_targets
+    m_csv
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/csv/include/CMakeLists.txt
+++ b/src/libraries/csv/include/CMakeLists.txt
@@ -1,5 +1,7 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/csv
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_csv PUBLIC FILE_SET HEADERS FILES 
+    m/csv/breaker.h 
+    m/csv/field_quoter.h 
+    m/csv/writer.h 
 )

--- a/src/libraries/csv/src/CMakeLists.txt
+++ b/src/libraries/csv/src/CMakeLists.txt
@@ -1,14 +1,14 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-add_library(csv STATIC
+target_sources(m_csv PRIVATE
     csv.cpp
     breaker.cpp)
 
-target_include_directories(csv PUBLIC
+target_include_directories(m_csv PUBLIC
     ../include
 )
 
-target_link_libraries(csv PUBLIC
-    io
-    math
+target_link_libraries(m_csv PUBLIC
+    m_io
+    m_math
 )

--- a/src/libraries/csv/test/CMakeLists.txt
+++ b/src/libraries/csv/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 if(M_BUILD_TESTS)
 
@@ -11,8 +11,8 @@ if(M_BUILD_TESTS)
 
     target_link_libraries(
       test_csv
-      csv
-      math
+      m_csv
+      m_math
       GTest::gtest_main
     )
 

--- a/src/libraries/filesystem/CMakeLists.txt
+++ b/src/libraries/filesystem/CMakeLists.txt
@@ -1,5 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_filesystem STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(test)
+
+list(APPEND m_installation_targets
+    m_filesystem
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/filesystem/include/CMakeLists.txt
+++ b/src/libraries/filesystem/include/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/filesystem
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_filesystem PUBLIC FILE_SET HEADERS FILES 
+    m/filesystem/filesystem.h 
 )

--- a/src/libraries/filesystem/src/CMakeLists.txt
+++ b/src/libraries/filesystem/src/CMakeLists.txt
@@ -1,22 +1,21 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-# Define the library
-add_library(filesystem STATIC
+target_sources(m_filesystem PRIVATE
     file.cpp
     filesystem.cpp
     make_path.cpp)
 
-target_compile_definitions(filesystem PRIVATE _CRT_SECURE_NO_WARNINGS)
+target_compile_definitions(m_filesystem PRIVATE _CRT_SECURE_NO_WARNINGS)
 
-target_link_libraries(filesystem PUBLIC
-    block_buffer
-    byte_streams
-    cast
-    math
-    memory
-    strings
+target_link_libraries(m_filesystem PUBLIC
+    m_block_buffer
+    m_byte_streams
+    m_cast
+    m_math
+    m_memory
+    m_strings
 )
 
-target_include_directories(filesystem PUBLIC
+target_include_directories(m_filesystem PUBLIC
     ../include
 )

--- a/src/libraries/filesystem/test/CMakeLists.txt
+++ b/src/libraries/filesystem/test/CMakeLists.txt
@@ -1,2 +1,2 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 

--- a/src/libraries/io/CMakeLists.txt
+++ b/src/libraries/io/CMakeLists.txt
@@ -1,4 +1,12 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_io STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
+
+list(APPEND m_installation_targets
+    m_io
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/io/include/CMakeLists.txt
+++ b/src/libraries/io/include/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/io
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_io PUBLIC FILE_SET HEADERS FILES 
+    m/io/units.h 
 )

--- a/src/libraries/io/src/CMakeLists.txt
+++ b/src/libraries/io/src/CMakeLists.txt
@@ -1,14 +1,14 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-add_library(io STATIC
+target_sources(m_io PRIVATE
     io.cpp
 )
 
-target_link_libraries(io PUBLIC
-    cast
-    math
+target_link_libraries(m_io PUBLIC
+    m_cast
+    m_math
 )
 
-target_include_directories(io PUBLIC
+target_include_directories(m_io PUBLIC
     ../include
 )

--- a/src/libraries/math/CMakeLists.txt
+++ b/src/libraries/math/CMakeLists.txt
@@ -1,5 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_math STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(test)
+
+list(APPEND m_installation_targets
+    m_math
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/math/include/CMakeLists.txt
+++ b/src/libraries/math/include/CMakeLists.txt
@@ -1,5 +1,7 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/math
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_math PUBLIC FILE_SET HEADERS FILES 
+    m/math/functors.h 
+    m/math/integer_functor_macros.h
+    m/math/math.h 
 )

--- a/src/libraries/math/src/CMakeLists.txt
+++ b/src/libraries/math/src/CMakeLists.txt
@@ -1,13 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-add_library(math STATIC
+target_sources(m_math PRIVATE
     math.cpp
 )
 
-target_include_directories(math PUBLIC
+target_include_directories(m_math PUBLIC
     ../include
 )
 
-target_link_libraries(math PUBLIC
-    cast
+target_link_libraries(m_math PUBLIC
+    m_cast
 )

--- a/src/libraries/math/test/CMakeLists.txt
+++ b/src/libraries/math/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 if(M_BUILD_TESTS)
     include(GoogleTest)
@@ -13,7 +13,7 @@ if(M_BUILD_TESTS)
 
     target_link_libraries(
       test_math
-      math
+      m_math
       GTest::gtest_main
     )
 

--- a/src/libraries/memory/CMakeLists.txt
+++ b/src/libraries/memory/CMakeLists.txt
@@ -1,5 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_memory STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(test)
+
+list(APPEND m_installation_targets
+    m_memory
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/memory/include/CMakeLists.txt
+++ b/src/libraries/memory/include/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/memory
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_memory PUBLIC FILE_SET HEADERS FILES 
+    m/memory/memory.h
 )

--- a/src/libraries/memory/src/CMakeLists.txt
+++ b/src/libraries/memory/src/CMakeLists.txt
@@ -1,14 +1,14 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-add_library(memory STATIC
+target_sources(m_memory PRIVATE
     memory.cpp
 )
 
-target_include_directories(memory PUBLIC
+target_include_directories(m_memory PUBLIC
     ../include
 )
 
-target_link_libraries(memory PUBLIC
-    block_buffer
-    math
+target_link_libraries(m_memory PUBLIC
+    m_block_buffer
+    m_math
 )

--- a/src/libraries/memory/test/CMakeLists.txt
+++ b/src/libraries/memory/test/CMakeLists.txt
@@ -1,1 +1,1 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)

--- a/src/libraries/pe/CMakeLists.txt
+++ b/src/libraries/pe/CMakeLists.txt
@@ -1,5 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_pe STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(test)
+
+list(APPEND m_installation_targets
+    m_pe
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/pe/doc/CMakeLists.txt
+++ b/src/libraries/pe/doc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 include(FindDoxygen)
 include(DoxygenTarget)

--- a/src/libraries/pe/include/CMakeLists.txt
+++ b/src/libraries/pe/include/CMakeLists.txt
@@ -1,5 +1,23 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/pe
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_pe PUBLIC FILE_SET HEADERS FILES 
+    m/pe/basic_types.h
+    m/pe/file_offset_t.h
+    m/pe/image_data_directory.h
+    m/pe/image_dos_header.h
+    m/pe/image_export_directory.h
+    m/pe/image_file_header.h
+    m/pe/image_import_by_name.h
+    m/pe/image_import_descriptor.h
+    m/pe/image_magic_t.h
+    m/pe/image_nt_headers.h
+    m/pe/image_optional_headers.h
+    m/pe/image_section_header.h
+    m/pe/loader_context.h
+    m/pe/offset_t.h
+    m/pe/pe.h
+    m/pe/pe_decoder.h
+    m/pe/position_t.h
+    m/pe/rva_stream.h
+    m/pe/rva_t.h
 )

--- a/src/libraries/pe/src/CMakeLists.txt
+++ b/src/libraries/pe/src/CMakeLists.txt
@@ -1,17 +1,17 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-add_library(pe STATIC
+target_sources(m_pe PRIVATE
     pe_decoder.cpp
     loader_context.cpp)
 
-target_include_directories(pe PUBLIC
+target_include_directories(m_pe PUBLIC
     ../include
 )
 
-target_link_libraries(pe PUBLIC
-    byte_streams
-    cast
-    filesystem
-    math
-    memory
+target_link_libraries(m_pe PUBLIC
+    m_byte_streams
+    m_cast
+    m_filesystem
+    m_math
+    m_memory
 )

--- a/src/libraries/pe/test/CMakeLists.txt
+++ b/src/libraries/pe/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 if(M_BUILD_TESTS)
     include(GoogleTest)
@@ -10,11 +10,11 @@ if(M_BUILD_TESTS)
 
     target_link_libraries(
       test_pe
-      byte_streams
-      filesystem
-      math
-      memory
-      pe
+      m_byte_streams
+      m_filesystem
+      m_math
+      m_memory
+      m_pe
       GTest::gtest_main
     )
 

--- a/src/libraries/strings/CMakeLists.txt
+++ b/src/libraries/strings/CMakeLists.txt
@@ -1,6 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_strings STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(test)
 
+list(APPEND m_installation_targets
+    m_strings
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/strings/include/CMakeLists.txt
+++ b/src/libraries/strings/include/CMakeLists.txt
@@ -1,5 +1,9 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/strings
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_strings PUBLIC FILE_SET HEADERS FILES 
+    m/strings/convert.h 
+    m/strings/literal_string_view.h 
+    m/strings/ordinal_compare.h 
+    m/strings/punning.h
+    m/strings/static_string.h 
 )

--- a/src/libraries/strings/src/CMakeLists.txt
+++ b/src/libraries/strings/src/CMakeLists.txt
@@ -1,20 +1,15 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-add_library(strings STATIC
+target_sources(m_strings PRIVATE
     convert.cpp
     punning.cpp
 )
 
-target_include_directories(strings PUBLIC
+target_include_directories(m_strings PUBLIC
     ../include
 )
 
-target_link_libraries(strings PUBLIC
-    math
-    utf
+target_link_libraries(m_strings PUBLIC
+    m_math
+    m_utf
 )
-
-set_target_properties(strings PROPERTIES
-    VERSION ${VERSION}
-)
-

--- a/src/libraries/strings/test/CMakeLists.txt
+++ b/src/libraries/strings/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 if(M_BUILD_TESTS)
     include(GoogleTest)
@@ -11,9 +11,9 @@ if(M_BUILD_TESTS)
 
     target_link_libraries(
       test_strings
-      cast
-      strings
-      math
+      m_cast
+      m_strings
+      m_math
       GTest::gtest_main
     )
 

--- a/src/libraries/tracing/CMakeLists.txt
+++ b/src/libraries/tracing/CMakeLists.txt
@@ -1,5 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_tracing STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(test)
+
+list(APPEND m_installation_targets
+    m_tracing
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/tracing/include/CMakeLists.txt
+++ b/src/libraries/tracing/include/CMakeLists.txt
@@ -1,5 +1,20 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/tracing
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_tracing PUBLIC FILE_SET HEADERS FILES 
+    m/tracing/channel.h 
+    m/tracing/cout_sink.h 
+    m/tracing/envelope.h 
+    m/tracing/event_context.h 
+    m/tracing/event_kind.h 
+    m/tracing/message.h 
+    m/tracing/message_queue.h 
+    m/tracing/monitor_class.h 
+    m/tracing/monitor_class_var.h 
+    m/tracing/multiplexor.h 
+    m/tracing/on_message_disposition.h 
+    m/tracing/safe_array_iterator.h 
+    m/tracing/sink.h 
+    m/tracing/source.h 
+    m/tracing/topology_version.h 
+    m/tracing/tracing.h 
 )

--- a/src/libraries/tracing/include/m/tracing/monitor_class.h
+++ b/src/libraries/tracing/include/m/tracing/monitor_class.h
@@ -53,8 +53,10 @@ namespace m
             std::shared_ptr<source>
             make_source(event_kind kind = event_kind::information);
 
+#if 0
             std::shared_ptr<source>
             make_source(event_kind kind, std::initializer_list<m::wliteral_string_view> channels);
+#endif
 
             void
             register_sink(std::shared_ptr<sink> snk);

--- a/src/libraries/tracing/src/CMakeLists.txt
+++ b/src/libraries/tracing/src/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-add_library(tracing STATIC
+target_sources(m_tracing PRIVATE
     channel.cpp
     cout_sink.cpp
     envelope.cpp
@@ -13,17 +13,12 @@ add_library(tracing STATIC
     source.cpp
   )
 
-target_include_directories(tracing PUBLIC
+target_include_directories(m_tracing PUBLIC
     ../include
 )
 
-target_link_libraries(tracing PUBLIC
-    math
-    strings
-    utf
+target_link_libraries(m_tracing PUBLIC
+    m_math
+    m_strings
+    m_utf
 )
-
-set_target_properties(tracing PROPERTIES
-    VERSION ${VERSION}
-)
-

--- a/src/libraries/tracing/test/CMakeLists.txt
+++ b/src/libraries/tracing/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 if(M_BUILD_TESTS)
     include(GoogleTest)
@@ -10,10 +10,10 @@ if(M_BUILD_TESTS)
 
     target_link_libraries(
       test_tracing
-      cast
-      math
-      strings
-      tracing
+      m_cast
+      m_math
+      m_strings
+      m_tracing
       GTest::gtest_main
     )
 

--- a/src/libraries/utf/CMakeLists.txt
+++ b/src/libraries/utf/CMakeLists.txt
@@ -1,5 +1,13 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_utf STATIC)
 
 add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(test)
+
+list(APPEND m_installation_targets
+    m_utf
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/utf/include/CMakeLists.txt
+++ b/src/libraries/utf/include/CMakeLists.txt
@@ -1,5 +1,8 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-install(DIRECTORY m/utf
-        DESTINATION ${M_INSTALL_INCLUDEDIR}
+target_sources(m_utf PUBLIC FILE_SET HEADERS FILES 
+    m/utf/decode_result.h 
+    m/utf/exceptions.h 
+    m/utf/utf_decode.h 
+    m/utf/utf_encode.h 
 )

--- a/src/libraries/utf/src/CMakeLists.txt
+++ b/src/libraries/utf/src/CMakeLists.txt
@@ -1,21 +1,16 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
-add_library(utf STATIC
+target_sources(m_utf PRIVATE
     utf.cpp
     decode_utf8.cpp
     decode_utf16.cpp
     decode_utf32.cpp 
     encoding_size.cpp)
 
-target_include_directories(utf PUBLIC
+target_include_directories(m_utf PUBLIC
     ../include
 )
 
-target_link_libraries(utf PUBLIC
-    math
+target_link_libraries(m_utf PUBLIC
+    m_math
 )
-
-set_target_properties(utf PROPERTIES
-    VERSION ${VERSION}
-)
-

--- a/src/libraries/utf/test/CMakeLists.txt
+++ b/src/libraries/utf/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 if(M_BUILD_TESTS)
     include(GoogleTest)
@@ -15,9 +15,9 @@ if(M_BUILD_TESTS)
 
     target_link_libraries(
       test_utf
-      cast
-      strings
-      math
+      m_cast
+      m_strings
+      m_math
       GTest::gtest_main
     )
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 add_subdirectory(bin2cpp)
 add_subdirectory(helloworld)

--- a/src/tools/bin2cpp/CMakeLists.txt
+++ b/src/tools/bin2cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 add_subdirectory(src)
 #add_subdirectory(doc)

--- a/src/tools/bin2cpp/src/CMakeLists.txt
+++ b/src/tools/bin2cpp/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 set(APP_SOURCES
   bin2cpp.cpp

--- a/src/tools/bin2cpp/test/CMakeLists.txt
+++ b/src/tools/bin2cpp/test/CMakeLists.txt
@@ -1,1 +1,1 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)

--- a/src/tools/helloworld/CMakeLists.txt
+++ b/src/tools/helloworld/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 add_subdirectory(src)
 

--- a/src/tools/helloworld/src/CMakeLists.txt
+++ b/src/tools/helloworld/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 add_executable(helloworld helloworld.cpp)
 

--- a/src/tools/pe2csv/CMakeLists.txt
+++ b/src/tools/pe2csv/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 add_subdirectory(src)
 

--- a/src/tools/pe2csv/src/CMakeLists.txt
+++ b/src/tools/pe2csv/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 add_executable(pe2csv
     main.cpp)
@@ -6,9 +6,9 @@ add_executable(pe2csv
 target_compile_definitions(pe2csv PUBLIC _CRT_SECURE_NO_WARNINGS)
 
 target_link_libraries(pe2csv
-    byte_streams
-    command_options
-    csv
-    filesystem
-    pe
+    m_byte_streams
+    m_command_options
+    m_csv
+    m_filesystem
+    m_pe
 )

--- a/src/tools/pe2l/CMakeLists.txt
+++ b/src/tools/pe2l/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 add_subdirectory(src)
 

--- a/src/tools/pe2l/src/CMakeLists.txt
+++ b/src/tools/pe2l/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 
 add_executable(pe2l
     main.cpp "traverse.cpp" "traverse.h")
@@ -6,11 +6,11 @@ add_executable(pe2l
 target_compile_definitions(pe2l PUBLIC _CRT_SECURE_NO_WARNINGS)
 
 target_link_libraries(pe2l
-    byte_streams
-    command_options
-    csv
-    filesystem
-    pe
+    m_byte_streams
+    m_command_options
+    m_csv
+    m_filesystem
+    m_pe
 )
 
 set_target_properties(pe2l PROPERTIES


### PR DESCRIPTION
Distribute the installation data down to the subdirectories.

Have each subdirectory propagate the list contents back to the parent so that the parent can then do the installation. Perhaps this is unnecessary. I'm still working backwards from assuming that the gRPC pattern was correct, learning that most of it was unnecessary but it's hard to know what to let go of.

It's not clear whether there should be one "install()" call per target or per project. If it's one per target then yes they should occur down in the leaves, if it's one per project then it belongs up mostly up at the top level CMakeLists.txt.

tbd.
