### PR TITLE
Make the Windows CP_ACP conversion functions have unique names

### DIFF
--- a/src/Windows/libraries/multi_byte/include/m/multi_byte/multi_byte.h
+++ b/src/Windows/libraries/multi_byte/include/m/multi_byte/multi_byte.h
@@ -75,7 +75,7 @@ namespace m
 
         template <typename OutIter, typename Utf16CharT = wchar_t, std::size_t BufferSize = 128>
         OutIter
-        multi_byte_to_utf16(code_page cp, std::string_view const& in, OutIter it)
+        multi_byte_to_utf16(code_page cp, std::string_view in, OutIter it)
             requires std::output_iterator<OutIter, Utf16CharT> &&
                      (std::is_same_v<Utf16CharT, wchar_t> || std::is_same_v<Utf16CharT, char16_t>)
         {
@@ -165,7 +165,7 @@ namespace m
 
         template <typename OutIter, typename Utf16CharT, std::size_t BufferSize = 128>
         OutIter
-        acp_to_utf16(std::string_view const& in, OutIter it)
+        acp_to_utf16(std::string_view in, OutIter it)
             requires std::output_iterator<OutIter, Utf16CharT> &&
                      (std::is_same_v<Utf16CharT, wchar_t> || std::is_same_v<Utf16CharT, char16_t>)
         {
@@ -321,10 +321,10 @@ namespace m
         }
 
         void
-        utf16_to_acp(std::wstring_view const& view, std::string& string);
+        utf16_to_acp(std::wstring_view view, std::string& string);
 
         void
-        utf16_to_acp(std::u16string_view const& view, std::string& string);
+        utf16_to_acp(std::u16string_view view, std::string& string);
 
         template <typename OutIter,
                   typename Utf16CharT    = wchar_t,
@@ -349,27 +349,39 @@ namespace m
 
     // Conversions to and from CP_ACP
     std::string
-    to_string(std::wstring_view const& view);
+    to_string_acp(std::wstring_view view);
+
+    std::u8string
+    to_u8string_acp(std::wstring_view view);
 
     std::string
-    to_string(std::u16string_view const& view);
+    to_string_acp(std::u16string_view view);
+
+    std::u8string
+    to_u8string_acp(std::u16string_view view);
 
     std::wstring
-    to_wstring(std::string_view const& view);
+    to_wstring_acp(std::string_view view);
+
+    std::wstring
+    to_wstring_acp(std::u8string_view view);
 
     std::u16string
-    to_u16string(std::string_view const& view);
+    to_u16string_acp(std::string_view view);
+
+    std::u16string
+    to_u16string_acp(std::u8string_view view);
 
     // and again with explicit code page specifications
     std::string
-    to_string(multi_byte::code_page cp, std::wstring_view const& view);
+    to_string(multi_byte::code_page cp, std::wstring_view view);
 
     std::string
-    to_string(multi_byte::code_page cp, std::u16string_view const& view);
+    to_string(multi_byte::code_page cp, std::u16string_view view);
 
     std::wstring
-    to_wstring(multi_byte::code_page cp, std::string_view const& view);
+    to_wstring(multi_byte::code_page cp, std::string_view view);
 
     std::u16string
-    to_u16string(multi_byte::code_page cp, std::string_view const& view);
+    to_u16string(multi_byte::code_page cp, std::string_view view);
 } // namespace m

--- a/src/Windows/libraries/multi_byte/src/multi_byte_to_utf16.cpp
+++ b/src/Windows/libraries/multi_byte/src/multi_byte_to_utf16.cpp
@@ -129,7 +129,7 @@ m::multi_byte::acp_to_utf16(std::string_view view, std::span<char16_t>& buffer)
 }
 
 std::wstring
-m::to_wstring(std::string_view const& view)
+m::to_wstring_acp(std::string_view view)
 {
     std::wstring string;
     //    auto         outit = std::back_inserter(string);
@@ -138,7 +138,7 @@ m::to_wstring(std::string_view const& view)
 }
 
 std::u16string
-m::to_u16string(std::string_view const& view)
+m::to_u16string_acp(std::string_view view)
 {
     std::u16string string;
     //    auto         outit = std::back_inserter(string);
@@ -147,7 +147,7 @@ m::to_u16string(std::string_view const& view)
 }
 
 std::wstring
-m::to_wstring(m::multi_byte::code_page cp, std::string_view const& view)
+m::to_wstring(m::multi_byte::code_page cp, std::string_view view)
 {
     std::wstring string;
     m::multi_byte::multi_byte_to_utf16(cp, view, string);
@@ -155,7 +155,7 @@ m::to_wstring(m::multi_byte::code_page cp, std::string_view const& view)
 }
 
 std::u16string
-m::to_u16string(m::multi_byte::code_page cp, std::string_view const& view)
+m::to_u16string(m::multi_byte::code_page cp, std::string_view view)
 {
     std::u16string string;
     m::multi_byte::multi_byte_to_utf16(cp, view, string);

--- a/src/Windows/libraries/multi_byte/src/utf16_to_multi_byte.cpp
+++ b/src/Windows/libraries/multi_byte/src/utf16_to_multi_byte.cpp
@@ -163,13 +163,13 @@ namespace m::multi_byte
     }
 
     void
-    utf16_to_acp(std::wstring_view const& view, std::string& string)
+    utf16_to_acp(std::wstring_view view, std::string& string)
     {
         utf16_to_multi_byte(cp_acp, view, string);
     }
 
     void
-    utf16_to_acp(std::u16string_view const& view, std::string& string)
+    utf16_to_acp(std::u16string_view view, std::string& string)
     {
         utf16_to_multi_byte(cp_acp, view, string);
     }
@@ -177,7 +177,7 @@ namespace m::multi_byte
 } // namespace m::multi_byte
 
 std::string
-m::to_string(std::wstring_view const& view)
+m::to_string_acp(std::wstring_view view)
 {
     std::string string;
     m::multi_byte::utf16_to_acp(view, string);
@@ -185,7 +185,7 @@ m::to_string(std::wstring_view const& view)
 }
 
 std::string
-m::to_string(std::u16string_view const& view)
+m::to_string_acp(std::u16string_view view)
 {
     std::string string;
     m::multi_byte::utf16_to_acp(view, string);
@@ -193,7 +193,7 @@ m::to_string(std::u16string_view const& view)
 }
 
 std::string
-m::to_string(m::multi_byte::code_page cp, std::wstring_view const& view)
+m::to_string(m::multi_byte::code_page cp, std::wstring_view view)
 {
     std::string string;
     m::multi_byte::utf16_to_multi_byte(cp, view, string);
@@ -201,7 +201,7 @@ m::to_string(m::multi_byte::code_page cp, std::wstring_view const& view)
 }
 
 std::string
-m::to_string(m::multi_byte::code_page cp, std::u16string_view const& view)
+m::to_string(m::multi_byte::code_page cp, std::u16string_view view)
 {
     std::string string;
     m::multi_byte::utf16_to_multi_byte(cp, view, string);

--- a/src/Windows/libraries/multi_byte/test/test_acp_apis.cpp
+++ b/src/Windows/libraries/multi_byte/test/test_acp_apis.cpp
@@ -32,33 +32,33 @@ auto u16sv_t1 =
 
 TEST(AcpAPIs, acp_2_wstring)
 {
-    auto s = m::to_wstring(s_t1);
+    auto s = m::to_wstring_acp(s_t1);
     EXPECT_EQ(s, ws_t1);
 
-    auto s2 = m::to_wstring(sv_t1);
+    auto s2 = m::to_wstring_acp(sv_t1);
     EXPECT_EQ(s2, ws_t1);
 }
 
 TEST(AcpAPIs, acp_2_u16string)
 {
-    auto s = m::to_u16string(s_t1);
+    auto s = m::to_u16string_acp(s_t1);
     EXPECT_EQ(s, u16sv_t1);
 
-    auto s2 = m::to_u16string(sv_t1);
+    auto s2 = m::to_u16string_acp(sv_t1);
     EXPECT_EQ(s2, u16sv_t1);
 }
 
 TEST(AcpAPIs, wstring_2_acp)
 {
-    auto s1 = m::to_string(ws_t1);
+    auto s1 = m::to_string_acp(ws_t1);
     EXPECT_EQ(s1, s_t1);
 
-    auto s2 = m::to_string(wsv_t1);
+    auto s2 = m::to_string_acp(wsv_t1);
     EXPECT_EQ(s2, s_t1);
 }
 
 TEST(AcpAPIs, u16string_2_acp)
 {
-    auto s1 = m::to_string(u16sv_t1);
+    auto s1 = m::to_string_acp(u16sv_t1);
     EXPECT_EQ(s1, s_t1);
 }


### PR DESCRIPTION
Give the Windows CP_ACP conversion functions in multi_byte.h unique names so that they can be used side-by-side with the more general purpose conversion functions in convert.h.
