### PR TITLE
Fix char/char8_t punning and add tests

### DIFF
--- a/src/Windows/libraries/multi_byte/src/acp_conversions.cpp
+++ b/src/Windows/libraries/multi_byte/src/acp_conversions.cpp
@@ -21,13 +21,15 @@ namespace m
     std::wstring
     acp_to_wstring(std::string_view view)
     {
-        return to_wstring(multi_byte::cp_acp, view);
+        std::wstring str;
+        acp_to_wstring(view, str);
+        return str;
     }
 
     void
     acp_to_wstring(std::string_view view, std::wstring& str)
     {
-        acp_to_wstring(view, str);
+        to_wstring(multi_byte::cp_acp, view, str);
     }
 
     void
@@ -71,6 +73,4 @@ namespace m
         acp_to_u32string(v, str);
         return str;
     }
-
-    //
 } // namespace m

--- a/src/libraries/strings/include/m/strings/punning.h
+++ b/src/libraries/strings/include/m/strings/punning.h
@@ -6,33 +6,41 @@
 #include <cstddef>
 #include <string_view>
 
+//
+// These are relatively type-unsafe coercions which assume that
+// two types are the same size and alignment and therefore that
+// views of one sort can be used equally as views of another
+// sort.
+// 
+// Primarily this is to enable playing fast and loose between
+// the type-safe char8_t which is well-defined as indicating that
+// basic_string<char8_t> (a/k/a u8string) is encoded using UTF-8
+// and basic_string<char> (a/k/a std::string) which on OSS from
+// the Unix/Linux world commonly assumes that std::string is
+// UTF-8 encoded.
+// 
+// The idempotent functions are provided so that code can be written
+// to not care which platform is being targeted in case there is some
+// variance.
+//
+
 namespace m
 {
-    namespace strings
-    {
-        using byte_string_view = std::basic_string_view<std::byte>;
-
-        byte_string_view
-        as_byte_string_view(std::u8string_view const& view);
-
-        byte_string_view
-        as_byte_string_view(std::string_view const& view);
-
         //
-        // Linux equates char with char8_t and wchar_t with char32_t, so
-        // we will take the bull by the horns and use these punnings to force
-        // use of the Utf-8 conversions on Linux.
-        //
-        // Windows, unfortunately, is still left adrift w.r.t. what to do
-        // about char to wchar_t.
+        // Should these really take <foo>_view&& ?
+        // 
+        // The lifetime management issues still confound me.
         //
 
         std::u8string_view
         as_u8string_view(std::string_view const& view);
 
-#ifndef WIN32
-        std::u32string_view
-        as_u32string_view(std::wstring_view const& view);
-#endif
-    } // namespace strings
+        std::u8string_view
+        as_u8string_view(std::u8string_view const& view);
+
+        std::string_view
+        as_string_view(std::u8string_view const& view);
+
+        std::string_view
+        as_string_view(std::string_view const& view);
 } // namespace m

--- a/src/libraries/strings/src/punning.cpp
+++ b/src/libraries/strings/src/punning.cpp
@@ -3,32 +3,28 @@
 
 #include <m/strings/punning.h>
 
-m::strings::byte_string_view
-m::strings::as_byte_string_view(std::u8string_view const& view)
-{
-    m::strings::byte_string_view rv(reinterpret_cast<std::byte const*>(view.data()), view.size());
-    return rv;
-}
-
-m::strings::byte_string_view
-m::strings::as_byte_string_view(std::string_view const& view)
-{
-    m::strings::byte_string_view rv(reinterpret_cast<std::byte const*>(view.data()), view.size());
-    return rv;
-}
-
 std::u8string_view
-m::strings::as_u8string_view(std::string_view const& view)
+m::as_u8string_view(std::string_view const& view)
 {
     std::u8string_view rv(reinterpret_cast<char8_t const*>(view.data()), view.size());
     return rv;
 }
 
-#ifndef WIN32
-std::u32string_view
-m::strings::as_u32string_view(std::wstring_view const& view)
+std::u8string_view
+m::as_u8string_view(std::u8string_view const& view)
 {
-    std::u32string_view rv(reinterpret_cast<char32_t const*>(view.data()), view.size());
+    return view;
+}
+
+std::string_view
+m::as_string_view(std::u8string_view const& view)
+{
+    std::string_view rv(reinterpret_cast<char const*>(view.data()), view.size());
     return rv;
 }
-#endif
+
+std::string_view
+m::as_string_view(std::string_view const& view)
+{
+    return view;
+}

--- a/src/libraries/strings/test/CMakeLists.txt
+++ b/src/libraries/strings/test/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.23)
 if(M_BUILD_TESTS)
     include(GoogleTest)
 
-    add_executable(
-      test_strings
+    add_executable(test_strings
+        punning_test.cpp
       test_convert.cpp
       test_literal_string_view.cpp
       verify_to_string.cpp

--- a/src/libraries/strings/test/punning_test.cpp
+++ b/src/libraries/strings/test/punning_test.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include <format>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include <m/strings/convert.h>
+#include <m/strings/punning.h>
+
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+TEST(Punning, U8SVtoSV)
+{
+    std::u8string_view v1   = u8"hello"sv;
+    auto               v2   = m::as_string_view(v1);
+    constexpr bool     test = std::is_same_v<decltype(v2), std::string_view>;
+    EXPECT_TRUE(test);
+    static_assert(sizeof(decltype(v1)::value_type) == sizeof(decltype(v2)::value_type));
+    EXPECT_EQ(reinterpret_cast<void const*>(v1.data()), reinterpret_cast<void const*>(v2.data()));
+    EXPECT_EQ(v1.size(), v2.size());
+}
+
+TEST(Punning, U8SVtoU8SV)
+{
+    std::u8string_view v1   = u8"hello"sv;
+    auto               v2   = m::as_u8string_view(v1);
+    constexpr bool     test = std::is_same_v<decltype(v2), std::u8string_view>;
+    EXPECT_TRUE(test);
+    static_assert(sizeof(decltype(v1)::value_type) == sizeof(decltype(v2)::value_type));
+    EXPECT_EQ(reinterpret_cast<void const*>(v1.data()), reinterpret_cast<void const*>(v2.data()));
+    EXPECT_EQ(v1.size(), v2.size());
+}
+
+TEST(Punning, SVtoSV)
+{
+    std::string_view v1   = "hello"sv;
+    auto             v2   = m::as_string_view(v1);
+    constexpr bool   test = std::is_same_v<decltype(v2), std::string_view>;
+    EXPECT_TRUE(test);
+    static_assert(sizeof(decltype(v1)::value_type) == sizeof(decltype(v2)::value_type));
+    EXPECT_EQ(reinterpret_cast<void const*>(v1.data()), reinterpret_cast<void const*>(v2.data()));
+    EXPECT_EQ(v1.size(), v2.size());
+}
+
+TEST(Punning, SVtoU8SV)
+{
+    std::string_view v1   = "hello"sv;
+    auto             v2   = m::as_u8string_view(v1);
+    constexpr bool   test = std::is_same_v<decltype(v2), std::u8string_view>;
+    EXPECT_TRUE(test);
+    static_assert(sizeof(decltype(v1)::value_type) == sizeof(decltype(v2)::value_type));
+    EXPECT_EQ(reinterpret_cast<void const*>(v1.data()), reinterpret_cast<void const*>(v2.data()));
+    EXPECT_EQ(v1.size(), v2.size());
+}


### PR DESCRIPTION
Remove remedial char16_t / wchar_t punning from platform independent portion of tree; will add under Windows later