### PR TITLE
Overloads for std::formatter<> for Win32 types

### DIFF
--- a/src/Windows/libraries/CMakeLists.txt
+++ b/src/Windows/libraries/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.23)
 
 add_subdirectory(debugging)
 add_subdirectory(errors)
+add_subdirectory(formatters)
 add_subdirectory(multi_byte)
 add_subdirectory(windows_strings)
 

--- a/src/Windows/libraries/formatters/CMakeLists.txt
+++ b/src/Windows/libraries/formatters/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.23)
+
+add_library(m_formatters STATIC)
+
+add_subdirectory(include)
+add_subdirectory(src)
+add_subdirectory(test)
+
+list(APPEND m_installation_targets
+    m_formatters
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/Windows/libraries/formatters/include/CMakeLists.txt
+++ b/src/Windows/libraries/formatters/include/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.23)
+
+target_sources(m_formatters PUBLIC FILE_SET HEADERS FILES
+    m/formatters/FILETIME.h
+    m/formatters/FILE_ACTION.h
+    m/formatters/FILE_NOTIFY_EXTENDED_INFORMATION.h
+    m/formatters/FILE_NOTIFY_INFORMATION.h
+    m/formatters/NTSTATUS.h
+    m/formatters/OVERLAPPED.h
+    m/formatters/Win32ErrorCode.h
+)

--- a/src/Windows/libraries/formatters/include/m/formatters/FILETIME.h
+++ b/src/Windows/libraries/formatters/include/m/formatters/FILETIME.h
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+#pragma once
+
+#include <array>
+#include <chrono>
+#include <format>
+#include <string_view>
+
+#include <Windows.h>
+
+struct fmtFILETIME
+{
+    FILETIME filetime;
+};
+
+inline FILETIME
+toFILETIME(LARGE_INTEGER li)
+{
+    union
+    {
+        LARGE_INTEGER m_li;
+        FILETIME      m_ft;
+    } u{li};
+    return u.m_ft;
+}
+
+template <typename CharT>
+struct std::formatter<fmtFILETIME, CharT>
+{
+    union LocalUnion
+    {
+        FILETIME filetime;
+        int64_t  rep;
+    };
+
+    static_assert(sizeof(LocalUnion) == sizeof(int64_t));
+    static_assert(sizeof(LocalUnion) == sizeof(FILETIME));
+
+    //
+    // FILETIME is 100ns units, so for the ratio
+    // have the denominator be 1 billion divided by
+    // 100.
+    //
+    using FiletimeRatio    = std::ratio<1, 1'000'000'000 / 100>;
+    using FiletimeDuration = std::chrono::duration<int64_t, FiletimeRatio>;
+
+    template <typename ParseContext>
+    constexpr ParseContext::iterator
+    parse(ParseContext& ctx)
+    {
+        auto       it  = ctx.begin();
+        auto const end = ctx.end();
+
+        if (it != end && *it != '}')
+            throw std::format_error("Invalid format string");
+
+        return it;
+    }
+
+    template <typename FormatContext>
+    FormatContext::iterator
+    format(fmtFILETIME const& filetimeIn, FormatContext& ctx) const
+    {
+        auto out = ctx.out();
+
+        FILETIME ft = filetimeIn.filetime;
+
+        // Negative FILETIMEs are durations; positive FILETIMEs are
+        // date/times
+
+        if (ft.dwHighDateTime & 0x80000000)
+        {
+            ULARGE_INTEGER uli;
+            uli.HighPart = ft.dwHighDateTime;
+            uli.LowPart  = ft.dwLowDateTime;
+
+            auto const microseconds = std::chrono::duration_cast<std::chrono::microseconds>(
+                FiletimeDuration(uli.QuadPart));
+            double dus = -static_cast<double>(microseconds.count());
+            double dms = dus / 1000.0;
+            if constexpr (std::is_same_v<CharT, wchar_t>)
+                out = std::format_to(out, L"{{ms: {}}}", dms);
+            else
+                out = std::format_to(out, "{{ms: {}}}", dms);
+        }
+        else
+        {
+            constexpr std::array<wchar_t const*, 8> wdays{
+                L"Su", L"Mo", L"Tu", L"We", L"Th", L"Fr", L"Sa", L"OutOfRange"};
+            constexpr std::array<char const*, 8> days{
+                "Su", "Mo", "Tu", "We", "Th", "Fr", "Sa", "OutOfRange"};
+            SYSTEMTIME st{};
+            ::FileTimeToSystemTime(&ft, &st);
+            if constexpr (std::is_same_v<CharT, wchar_t>)
+                out = std::format_to(
+                    out,
+                    L"{{ {} {:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}.{:03d} }}",
+                    wdays[(std::min)(static_cast<size_t>(7), static_cast<size_t>(st.wDayOfWeek))],
+                    st.wYear,
+                    st.wMonth,
+                    st.wDay,
+                    st.wHour,
+                    st.wMinute,
+                    st.wHour,
+                    st.wMinute,
+                    st.wSecond,
+                    st.wMilliseconds);
+            else
+                out = std::format_to(
+                    out,
+                    "{{ {} {:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}.{:03d} }}",
+                    days[(std::min)(static_cast<size_t>(7), static_cast<size_t>(st.wDayOfWeek))],
+                    st.wYear,
+                    st.wMonth,
+                    st.wDay,
+                    st.wHour,
+                    st.wMinute,
+                    st.wHour,
+                    st.wMinute,
+                    st.wSecond,
+                    st.wMilliseconds);
+        }
+
+        return out;
+    }
+};

--- a/src/Windows/libraries/formatters/include/m/formatters/FILE_ACTION.h
+++ b/src/Windows/libraries/formatters/include/m/formatters/FILE_ACTION.h
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+#pragma once
+
+#include <format>
+
+#include <Windows.h>
+
+struct fmtFILE_ACTION
+{
+    DWORD file_action;
+};
+
+template <typename CharT>
+struct std::formatter<fmtFILE_ACTION, CharT>
+{
+    template <typename ParseContext>
+    constexpr ParseContext::iterator
+    parse(ParseContext& ctx)
+    {
+        auto       it  = ctx.begin();
+        auto const end = ctx.end();
+
+        if (it != end && *it != '}')
+            throw std::format_error("Invalid format string");
+
+        return it;
+    }
+
+    template <typename FormatContext>
+    FormatContext::iterator
+    format(fmtFILE_ACTION action, FormatContext& ctx) const
+    {
+        wstring_view text{};
+
+        switch (action.file_action)
+        {
+            case FILE_ACTION_ADDED: text = L"FILE_ACTION_ADDED"sv; break;
+            case FILE_ACTION_REMOVED: text = L"FILE_ACTION_REMOVED"sv; break;
+            case FILE_ACTION_MODIFIED: text = L"FILE_ACTION_MODIFIED"sv; break;
+            case FILE_ACTION_RENAMED_OLD_NAME: text = L"FILE_ACTION_RENAMED_OLD_NAME"sv; break;
+            case FILE_ACTION_RENAMED_NEW_NAME: text = L"FILE_ACTION_RENAMED_NEW_NAME"sv; break;
+            default: return std::format_to(ctx.out(), L"Unmapped action {}", action.file_action);
+        }
+
+        return std::copy(text.begin(), text.end(), ctx.out());
+    }
+};

--- a/src/Windows/libraries/formatters/include/m/formatters/FILE_NOTIFY_EXTENDED_INFORMATION.h
+++ b/src/Windows/libraries/formatters/include/m/formatters/FILE_NOTIFY_EXTENDED_INFORMATION.h
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+#pragma once
+
+#include <format>
+
+#include <Windows.h>
+
+#include "FILETIME.h"
+#include "FILE_ACTION.h"
+
+template <typename CharT>
+struct std::formatter<FILE_NOTIFY_EXTENDED_INFORMATION, CharT>
+{
+    template <typename ParseContext>
+    constexpr auto
+    parse(ParseContext& ctx)
+    {
+        auto       it  = ctx.begin();
+        auto const end = ctx.end();
+
+        if (it != end && *it != '}')
+            throw std::format_error("Invalid format string");
+
+        return it;
+    }
+
+    template <typename FormatContext>
+    FormatContext::iterator
+    format(FILE_NOTIFY_EXTENDED_INFORMATION const& fnei, FormatContext& ctx) const
+    {
+        fmtFILE_ACTION    fa{fnei.Action};
+        std::wstring_view fileName(fnei.FileName, fnei.FileNameLength / sizeof(WCHAR));
+
+        auto it = ctx.out();
+
+        it = std::format_to(
+            it,
+            L"{{ NextEntryOffset: {}, Action: {}, CreationTime: {}, LastModificationTime: {}, LastChangeTime: {}, LastAccessTime: {}, AllocatedLength: {}, FileSize: {}, FileAttributes: {:x}, ReparsePointTag: {}, FileId: {}, ParentFileId: {}, FileName: \"{}\" }}",
+            fnei.NextEntryOffset,
+            fa,
+            fmtFILETIME(toFILETIME(fnei.CreationTime)),
+            fmtFILETIME(toFILETIME(fnei.LastModificationTime)),
+            fmtFILETIME(toFILETIME(fnei.LastChangeTime)),
+            fmtFILETIME(toFILETIME(fnei.LastAccessTime)),
+            fnei.AllocatedLength.QuadPart,
+            fnei.FileSize.QuadPart,
+            fnei.FileAttributes,
+            fnei.ReparsePointTag,
+            fnei.FileId.QuadPart,
+            fnei.ParentFileId.QuadPart,
+            std::wstring_view(fnei.FileName, fnei.FileNameLength / sizeof(WCHAR)));
+
+        return it;
+    }
+};

--- a/src/Windows/libraries/formatters/include/m/formatters/FILE_NOTIFY_INFORMATION.h
+++ b/src/Windows/libraries/formatters/include/m/formatters/FILE_NOTIFY_INFORMATION.h
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+#pragma once
+
+#include <format>
+
+#include <Windows.h>
+
+#include "FILETIME.h"
+#include "FILE_ACTION.h"
+
+template <typename CharT>
+struct std::formatter<FILE_NOTIFY_INFORMATION, CharT>
+{
+    template <typename ParseContext>
+    constexpr ParseContext::iterator
+    parse(ParseContext& ctx)
+    {
+        auto       it  = ctx.begin();
+        auto const end = ctx.end();
+
+        if (it != end && *it != '}')
+            throw std::format_error("Invalid format string");
+
+        return it;
+    }
+
+    template <typename FormatContext>
+    FormatContext::iterator
+    format(FILE_NOTIFY_INFORMATION const& fni, FormatContext& ctx) const
+    {
+        fmtFILE_ACTION fa{fni.Action};
+        wstring_view   fileName(fni.FileName, fni.FileNameLength / sizeof(WCHAR));
+
+        return std::format_to(ctx.out(),
+                              L"{{ NextEntryOffset: {}, Action: {}, FileName: \"{}\" }}",
+                              fni.NextEntryOffset,
+                              fa,
+                              wstring_view(fni.FileName, fni.FileNameLength / sizeof(WCHAR)));
+    }
+};

--- a/src/Windows/libraries/formatters/include/m/formatters/NTSTATUS.h
+++ b/src/Windows/libraries/formatters/include/m/formatters/NTSTATUS.h
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <format>
+#include <string_view>
+
+#include <Windows.h>
+
+typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
+
+using namespace std::string_view_literals;
+
+struct fmtNTSTATUS
+{
+    // NTSTATUS is defined a (signed!) LONG, but the NTSTATUS
+    // constants are #define-d as (DWORD) 0xwhatever. So we have
+    // to allow for both signed and unsigned values here.
+    constexpr fmtNTSTATUS(int s_in): s(s_in) {}
+    constexpr fmtNTSTATUS(LONG s_in): s(s_in) {}
+    constexpr fmtNTSTATUS(DWORD s_in): s(s_in) {}
+    NTSTATUS s;
+};
+
+template <typename CharT>
+struct std::formatter<fmtNTSTATUS, CharT>
+{
+    template <typename ParseContext>
+    constexpr ParseContext::iterator
+    parse(ParseContext& ctx)
+    {
+        auto       it  = ctx.begin();
+        auto const end = ctx.end();
+
+        if (it != end && *it != '}')
+            throw std::format_error("Invalid format string");
+
+        return it;
+    }
+
+    template <typename FormatContext>
+    FormatContext::iterator
+    format(fmtNTSTATUS const& ntstatus, FormatContext& ctx) const
+    {
+        auto out = ctx.out();
+        auto s   = ntstatus.s;
+
+        switch (s)
+        {
+            case STATUS_PENDING: return std::ranges::copy(L"STATUS_PENDING"sv, out).out;
+            case STATUS_WAIT_0: return std::ranges::copy(L"STATUS_WAIT_0"sv, out).out;
+            case STATUS_ABANDONED_WAIT_0:
+                return std::ranges::copy(L"STATUS_ABANDONED_WAIT_0"sv, out).out;
+            case STATUS_INVALID_HANDLE:
+                return std::ranges::copy(L"STATUS_INVALID_HANDLE"sv, out).out;
+            case STATUS_INVALID_PARAMETER:
+                return std::ranges::copy(L"STATUS_INVALID_PARAMETER"sv, out).out;
+        }
+
+        return std::format_to(out, L"0x{:08x}", s);
+    }
+};

--- a/src/Windows/libraries/formatters/include/m/formatters/OVERLAPPED.h
+++ b/src/Windows/libraries/formatters/include/m/formatters/OVERLAPPED.h
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+#pragma once
+
+#include <format>
+
+#include <m/cast/to.h>
+
+#include <Windows.h>
+
+#include "NTSTATUS.h"
+
+typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
+
+template <typename CharT>
+struct std::formatter<OVERLAPPED, CharT>
+{
+    template <typename ParseContext>
+    constexpr ParseContext::iterator
+    parse(ParseContext& ctx)
+    {
+        auto       it  = ctx.begin();
+        auto const end = ctx.end();
+
+        if (it != end && *it != '}')
+            throw std::format_error("Invalid format string");
+
+        return it;
+    }
+
+    template <typename FormatContext>
+    FormatContext::iterator
+    format(OVERLAPPED const& o, FormatContext& ctx) const
+    {
+        // Pull apart the OVERLAPPED into its component pieces:
+        //
+        auto const s = static_cast<NTSTATUS>(o.Internal);
+        auto const bytesTransferred = m::to<uint64_t>(o.InternalHigh);
+        auto const offset = static_cast<uint64_t>(o.Offset) | (static_cast<uint64_t>(o.OffsetHigh) << 32);
+
+        return std::format_to(
+            ctx.out(),
+            L"{{ OVERLAPPED Status: {}, BytesTransferred: {}, Offset: {}, Handle: 0x{:x} }}",
+            fmtNTSTATUS{s},
+            bytesTransferred,
+            offset,
+            reinterpret_cast<uintptr_t>(o.hEvent));
+    }
+};

--- a/src/Windows/libraries/formatters/include/m/formatters/Win32ErrorCode.h
+++ b/src/Windows/libraries/formatters/include/m/formatters/Win32ErrorCode.h
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <format>
+#include <string_view>
+
+#include <Windows.h>
+
+using namespace std::string_view_literals;
+
+struct fmtWin32ErrorCode
+{
+    DWORD dwErrorCode;
+};
+
+template <typename CharT>
+struct std::formatter<fmtWin32ErrorCode, CharT>
+{
+    template <typename ParseContext>
+    constexpr ParseContext::iterator
+    parse(ParseContext& ctx)
+    {
+        auto       it  = ctx.begin();
+        auto const end = ctx.end();
+
+        if (it != end && *it != '}')
+            throw std::format_error("Invalid format string");
+
+        return it;
+    }
+
+    template <typename FormatContext>
+    FormatContext::iterator
+    format(fmtWin32ErrorCode const& w32ec, FormatContext& ctx) const
+    {
+        auto       out = ctx.out();
+        auto const ec  = w32ec.dwErrorCode;
+
+        wstring_view sv{};
+        switch (ec)
+        {
+            case ERROR_INVALID_FUNCTION: sv = L"ERROR_INVALID_FUNCTION"sv; break;
+            case ERROR_FILE_NOT_FOUND: sv = L"ERROR_FILE_NOT_FOUND"sv; break;
+            case ERROR_PATH_NOT_FOUND: sv = L"ERROR_PATH_NOT_FOUND"sv; break;
+            case ERROR_ACCESS_DENIED: sv = L"ERROR_ACCESS_DENIED"sv; break;
+            case ERROR_INVALID_HANDLE: sv = L"ERROR_INVALID_HANDLE"sv; break;
+            case ERROR_SHARING_VIOLATION: sv = L"ERROR_SHARING_VIOLATION"sv; break;
+        }
+
+        if (sv.size() != 0)
+            return std::format_to(out, L"{{ {} ({}) }}", sv, ec);
+
+        return std::format_to(out, L"{{ {} }}", ec);
+    }
+};

--- a/src/Windows/libraries/formatters/src/CMakeLists.txt
+++ b/src/Windows/libraries/formatters/src/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.23)
+
+target_sources(m_formatters PRIVATE
+    formatters.cpp
+)
+
+target_include_directories(m_formatters PUBLIC
+    ../include
+)
+
+target_link_libraries(m_formatters PUBLIC
+    m_cast
+)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/Windows/libraries/formatters/src/formatters.cpp
+++ b/src/Windows/libraries/formatters/src/formatters.cpp
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <format>
+
+#include <m/formatters/FILETIME.h>
+#include <m/formatters/FILE_ACTION.h>
+#include <m/formatters/FILE_NOTIFY_EXTENDED_INFORMATION.h>
+#include <m/formatters/FILE_NOTIFY_INFORMATION.h>
+#include <m/formatters/NTSTATUS.h>
+#include <m/formatters/OVERLAPPED.h>
+#include <m/formatters/Win32ErrorCode.h>

--- a/src/Windows/libraries/formatters/test/CMakeLists.txt
+++ b/src/Windows/libraries/formatters/test/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.23)
+
+if(M_BUILD_TESTS)
+    include(GoogleTest)
+
+    add_executable(test_formatters
+        test_FILETIME.cpp
+        test_FILE_ACTION.cpp
+        test_FILE_NOTIFY_EXTENDED_INFORMATION.cpp
+        test_FILE_NOTIFY_INFORMATION.cpp
+        test_NTSTATUS.cpp
+        test_OVERLAPPED.cpp
+        test_Win32ErrorCode.cpp
+    )
+
+    target_link_libraries(
+        test_formatters
+        m_formatters
+        GTest::gtest_main
+    )
+
+    enable_testing()
+
+    gtest_discover_tests(test_formatters)
+endif()

--- a/src/Windows/libraries/formatters/test/test_FILETIME.cpp
+++ b/src/Windows/libraries/formatters/test/test_FILETIME.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include <format>
+#include <string>
+#include <string_view>
+
+#include <m/formatters/FILETIME.h>
+
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+//
+// These are just two FILETIME values chosen more or less at random. The positive one was
+// just adjusted to be somewhat near to the current year of 2025.
+//
+constexpr FILETIME ft1{0x0, 0x01e00000};
+constexpr FILETIME negative_ft{0x0, 0x81e00000};
+
+TEST(FILETIME, lbasic)
+{
+    auto s = std::format(L"{}", fmtFILETIME(ft1));
+    EXPECT_EQ(s, L"{ Tu 2029-02-20 23:41:23.041 }"s);
+}
+
+TEST(FILETIME, lnegative)
+{
+    auto s = std::format(L"{}", fmtFILETIME(negative_ft));
+    EXPECT_EQ(s, L"{ms: 908826404803366.1}"s);
+}
+
+TEST(FILETIME, basic)
+{
+    auto s = std::format("{}", fmtFILETIME(ft1));
+    EXPECT_EQ(s, "{ Tu 2029-02-20 23:41:23.041 }"s);
+}
+
+TEST(FILETIME, negative)
+{
+    auto s = std::format("{}", fmtFILETIME(negative_ft));
+    EXPECT_EQ(s, "{ms: 908826404803366.1}"s);
+}
+
+
+
+

--- a/src/Windows/libraries/formatters/test/test_FILE_ACTION.cpp
+++ b/src/Windows/libraries/formatters/test/test_FILE_ACTION.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include <format>
+#include <string>
+#include <string_view>
+
+#include <m/formatters/FILE_ACTION.h>
+
+#include <Windows.h>
+
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+TEST(FILE_ACTION, format_FILE_ACTION_ADDED)
+{
+    auto s = std::format(L"{}", fmtFILE_ACTION{FILE_ACTION_ADDED});
+    EXPECT_EQ(s, L"FILE_ACTION_ADDED"s);
+}
+
+TEST(FILE_ACTION, format_FILE_ACTION_REMOVED)
+{
+    auto s = std::format(L"{}", fmtFILE_ACTION{FILE_ACTION_REMOVED});
+    EXPECT_EQ(s, L"FILE_ACTION_REMOVED"s);
+}
+
+TEST(FILE_ACTION, format_FILE_ACTION_MODIFIED)
+{
+    auto s = std::format(L"{}", fmtFILE_ACTION{FILE_ACTION_MODIFIED});
+    EXPECT_EQ(s, L"FILE_ACTION_MODIFIED"s);
+}
+
+TEST(FILE_ACTION, format_FILE_ACTION_RENAMED_OLD_NAME)
+{
+    auto s = std::format(L"{}", fmtFILE_ACTION{FILE_ACTION_RENAMED_OLD_NAME});
+    EXPECT_EQ(s, L"FILE_ACTION_RENAMED_OLD_NAME"s);
+}
+
+TEST(FILE_ACTION, format_FILE_ACTION_RENAMED_NEW_NAME)
+{
+    auto s = std::format(L"{}", fmtFILE_ACTION{FILE_ACTION_RENAMED_NEW_NAME});
+    EXPECT_EQ(s, L"FILE_ACTION_RENAMED_NEW_NAME"s);
+}
+
+TEST(FILE_ACTION, unmapped_0)
+{
+    auto s = std::format(L"{}", fmtFILE_ACTION{0});
+    EXPECT_EQ(s, L"Unmapped action 0"s);
+}
+
+TEST(FILE_ACTION, unmapped_DWORD_MAX)
+{
+    auto s = std::format(L"{}", fmtFILE_ACTION{(std::numeric_limits<DWORD>::max)()});
+    EXPECT_EQ(s, L"Unmapped action 4294967295"s);
+}
+
+
+
+
+
+

--- a/src/Windows/libraries/formatters/test/test_FILE_NOTIFY_EXTENDED_INFORMATION.cpp
+++ b/src/Windows/libraries/formatters/test/test_FILE_NOTIFY_EXTENDED_INFORMATION.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include <format>
+#include <string>
+#include <string_view>
+
+#include <m/formatters/FILE_NOTIFY_EXTENDED_INFORMATION.h>
+
+#include <Windows.h>
+
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+//
+// Copy of the definition of FILE_NOTIFY_EXTENDED_INFORMATION with
+// the character array expanded so we can put data in it.
+//
+
+struct testingFILE_NOTIFY_EXTENDED_INFORMATION
+{
+    DWORD         NextEntryOffset;
+    DWORD         Action;
+    LARGE_INTEGER CreationTime;
+    LARGE_INTEGER LastModificationTime;
+    LARGE_INTEGER LastChangeTime;
+    LARGE_INTEGER LastAccessTime;
+    LARGE_INTEGER AllocatedLength;
+    LARGE_INTEGER FileSize;
+    DWORD         FileAttributes;
+    union
+    {
+        DWORD ReparsePointTag;
+        DWORD EaSize;
+    } SomeUnion;
+    LARGE_INTEGER FileId;
+    LARGE_INTEGER ParentFileId;
+    DWORD         FileNameLength;
+    WCHAR         FileName[255];
+};
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, NextEntryOffset) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, NextEntryOffset));
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, Action) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, Action));
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, CreationTime) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, CreationTime));
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, LastModificationTime) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, LastModificationTime));
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, LastChangeTime) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, LastChangeTime));
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, LastAccessTime) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, LastAccessTime));
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, AllocatedLength) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, AllocatedLength));
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, FileSize) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, FileSize));
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, FileAttributes) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, FileAttributes));
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, SomeUnion.ReparsePointTag) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, ReparsePointTag));
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, FileId) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, FileId));
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, ParentFileId) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, ParentFileId));
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, FileNameLength) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, FileNameLength));
+
+static_assert(offsetof(testingFILE_NOTIFY_EXTENDED_INFORMATION, FileName) ==
+              offsetof(FILE_NOTIFY_EXTENDED_INFORMATION, FileName));
+
+constexpr LARGE_INTEGER some_file_time = {.LowPart = 0, .HighPart = 0x01f00000};
+
+constexpr LARGE_INTEGER large_integer_zero = {.QuadPart = 0};
+
+constexpr testingFILE_NOTIFY_EXTENDED_INFORMATION info1 = {.NextEntryOffset = 0,
+                                                           .Action          = FILE_ACTION_ADDED,
+                                                           .CreationTime    = some_file_time,
+                                                           .LastModificationTime = some_file_time,
+                                                           .LastChangeTime       = some_file_time,
+                                                           .LastAccessTime = large_integer_zero,
+                                                           .FileSize       = large_integer_zero,
+                                                           .FileAttributes = 0,
+                                                           .SomeUnion      = {.ReparsePointTag = 0},
+                                                           .FileId         = large_integer_zero,
+                                                           .ParentFileId   = large_integer_zero,
+                                                           .FileNameLength = 20,
+                                                           .FileName       = L"README.TXT"};
+
+TEST(FILE_NOTIFY_EXTENDED_INFORMATION, first)
+{
+    auto p = reinterpret_cast<FILE_NOTIFY_EXTENDED_INFORMATION const*>(&info1);
+    auto s = std::format(L"{}", *p);
+    EXPECT_EQ(s, L"{ NextEntryOffset: 0, Action: FILE_ACTION_ADDED, CreationTime: { Su 2043-05-31 11:40:11.040 }, LastModificationTime: { Su 2043-05-31 11:40:11.040 }, LastChangeTime: { Su 2043-05-31 11:40:11.040 }, LastAccessTime: { Mo 1601-01-01 00:00:00.000 }, AllocatedLength: 0, FileSize: 0, FileAttributes: 0, ReparsePointTag: 0, FileId: 0, ParentFileId: 0, FileName: \"README.TXT\" }"s);
+}

--- a/src/Windows/libraries/formatters/test/test_FILE_NOTIFY_INFORMATION.cpp
+++ b/src/Windows/libraries/formatters/test/test_FILE_NOTIFY_INFORMATION.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include <format>
+#include <string>
+#include <string_view>
+
+#include <m/formatters/FILE_NOTIFY_INFORMATION.h>
+
+#include <Windows.h>
+
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+//
+// Copy of the definition of FILE_NOTIFY_EXTENDED_INFORMATION with
+// the character array expanded so we can put data in it.
+//
+
+struct testingFILE_NOTIFY_INFORMATION
+{
+    DWORD         NextEntryOffset;
+    DWORD         Action;
+    DWORD         FileNameLength;
+    WCHAR         FileName[255];
+};
+
+static_assert(offsetof(testingFILE_NOTIFY_INFORMATION, NextEntryOffset) ==
+              offsetof(FILE_NOTIFY_INFORMATION, NextEntryOffset));
+
+static_assert(offsetof(testingFILE_NOTIFY_INFORMATION, Action) ==
+              offsetof(FILE_NOTIFY_INFORMATION, Action));
+
+static_assert(offsetof(testingFILE_NOTIFY_INFORMATION, FileNameLength) ==
+              offsetof(FILE_NOTIFY_INFORMATION, FileNameLength));
+
+static_assert(offsetof(testingFILE_NOTIFY_INFORMATION, FileName) ==
+              offsetof(FILE_NOTIFY_INFORMATION, FileName));
+
+constexpr testingFILE_NOTIFY_INFORMATION info1 = {.NextEntryOffset = 0,
+                                                           .Action          = FILE_ACTION_ADDED,
+                                                           .FileNameLength = 20,
+                                                           .FileName       = L"README.TXT"};
+
+TEST(FILE_NOTIFY_INFORMATION, first)
+{
+    auto p = reinterpret_cast<FILE_NOTIFY_INFORMATION const*>(&info1);
+    auto s = std::format(L"{}", *p);
+    EXPECT_EQ(s, L"{ NextEntryOffset: 0, Action: FILE_ACTION_ADDED, FileName: \"README.TXT\" }"s);
+}

--- a/src/Windows/libraries/formatters/test/test_NTSTATUS.cpp
+++ b/src/Windows/libraries/formatters/test/test_NTSTATUS.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include <format>
+#include <string>
+#include <string_view>
+
+#include <m/formatters/NTSTATUS.h>
+
+#include <Windows.h>
+
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+TEST(NTSTATUS, format_STATUS_PENDING)
+{
+    auto s = std::format(L"{}", fmtNTSTATUS{STATUS_PENDING});
+    EXPECT_EQ(s, L"STATUS_PENDING"s);
+}
+
+TEST(NTSTATUS, format_STATUS_WAIT_0)
+{
+    auto s = std::format(L"{}", fmtNTSTATUS{STATUS_WAIT_0});
+    EXPECT_EQ(s, L"STATUS_WAIT_0"s);
+}
+
+TEST(NTSTATUS, format_STATUS_ABANDONED_WAIT_0)
+{
+    auto s = std::format(L"{}", fmtNTSTATUS{STATUS_ABANDONED_WAIT_0});
+    EXPECT_EQ(s, L"STATUS_ABANDONED_WAIT_0"s);
+}
+
+TEST(NTSTATUS, format_STATUS_INVALID_HANDLE)
+{
+    auto s = std::format(L"{}", fmtNTSTATUS{STATUS_INVALID_HANDLE});
+    EXPECT_EQ(s, L"STATUS_INVALID_HANDLE"s);
+}
+
+TEST(NTSTATUS, format_STATUS_INVALID_PARAMETER)
+{
+    auto s = std::format(L"{}", fmtNTSTATUS{STATUS_INVALID_PARAMETER});
+    EXPECT_EQ(s, L"STATUS_INVALID_PARAMETER"s);
+}
+
+TEST(NTSTATUS, unmapped_42)
+{
+    auto s = std::format(L"{}", fmtNTSTATUS(42));
+    EXPECT_EQ(s, L"0x0000002a"s);
+}
+
+TEST(NTSTATUS, unmapped_DWORD_MAX)
+{
+    auto s = std::format(L"{}", fmtNTSTATUS{(std::numeric_limits<NTSTATUS>::max)()});
+    EXPECT_EQ(s, L"0x7fffffff"s);
+}
+
+
+
+
+
+

--- a/src/Windows/libraries/formatters/test/test_OVERLAPPED.cpp
+++ b/src/Windows/libraries/formatters/test/test_OVERLAPPED.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include <format>
+#include <string>
+#include <string_view>
+
+#include <m/formatters/OVERLAPPED.h>
+
+#include <Windows.h>
+
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+const OVERLAPPED data1 = {
+    .Internal     = 0, // Actually NTSTATUS
+    .InternalHigh = 0, // BytesTransferred
+    .Pointer      = nullptr,
+    .hEvent       = INVALID_HANDLE_VALUE,
+};
+
+TEST(OVERLAPPED, first)
+{
+    auto s = std::format(L"{}", data1);
+    EXPECT_EQ(s, L"{ OVERLAPPED Status: STATUS_WAIT_0, BytesTransferred: 0, Offset: 0, Handle: 0xffffffffffffffff }"s);
+}

--- a/src/Windows/libraries/formatters/test/test_Win32ErrorCode.cpp
+++ b/src/Windows/libraries/formatters/test/test_Win32ErrorCode.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include <format>
+#include <string>
+#include <string_view>
+
+#include <m/formatters/Win32ErrorCode.h>
+
+#include <Windows.h>
+
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+TEST(Win32ErrorCode, format_ERROR_INVALID_FUNCTION)
+{
+    auto s = std::format(L"{}", fmtWin32ErrorCode{ERROR_INVALID_FUNCTION});
+    EXPECT_EQ(s, L"{ ERROR_INVALID_FUNCTION (1) }"s);
+}
+
+TEST(Win32ErrorCode, format_ERROR_FILE_NOT_FOUND)
+{
+    auto s = std::format(L"{}", fmtWin32ErrorCode{ERROR_FILE_NOT_FOUND});
+    EXPECT_EQ(s, L"{ ERROR_FILE_NOT_FOUND (2) }"s);
+}
+
+TEST(Win32ErrorCode, format_ERROR_PATH_NOT_FOUND)
+{
+    auto s = std::format(L"{}", fmtWin32ErrorCode{ERROR_PATH_NOT_FOUND});
+    EXPECT_EQ(s, L"{ ERROR_PATH_NOT_FOUND (3) }"s);
+}
+
+TEST(Win32ErrorCode, format_ERROR_ACCESS_DENIED)
+{
+    auto s = std::format(L"{}", fmtWin32ErrorCode{ERROR_ACCESS_DENIED});
+    EXPECT_EQ(s, L"{ ERROR_ACCESS_DENIED (5) }"s);
+}
+
+TEST(Win32ErrorCode, unmapped_42)
+{
+    auto s = std::format(L"{}", fmtWin32ErrorCode(42));
+    EXPECT_EQ(s, L"{ 42 }"s);
+}
+
+TEST(Win32ErrorCode, unmapped_DWORD_MAX)
+{
+    auto s = std::format(L"{}", fmtWin32ErrorCode{(std::numeric_limits<DWORD>::max)()});
+    EXPECT_EQ(s, L"{ 4294967295 }"s);
+}
+
+
+
+
+
+

--- a/src/libraries/cast/src/CMakeLists.txt
+++ b/src/libraries/cast/src/CMakeLists.txt
@@ -7,3 +7,7 @@ target_sources(m_cast PRIVATE
 target_include_directories(m_cast PUBLIC
     ../include
 )
+
+target_link_libraries(m_cast PUBLIC
+    m_math
+)


### PR DESCRIPTION
Overloads of std::formatter<> for some common Win32 types that make debugging and tracing easier
