### PR TITLE
Fix the filesystem load and store

### DIFF
--- a/src/Windows/libraries/multi_byte/test/test_data.h
+++ b/src/Windows/libraries/multi_byte/test/test_data.h
@@ -17,18 +17,16 @@ struct utf_data_set
         m_u16le_chardata(utf16data.begin(), utf16data.end()),
         m_u32_chardata(utf32data.begin(), utf32data.end())
     {
-        m_u16be_chardata.resize(m_u16le_chardata.size());
-        for (std::size_t i = 0; i < m_u16le_chardata.size(); i++)
-        {
-            char16_t ch = m_u16le_chardata[i];
-            char16_t ch2 = ((ch & 0xff) << 8) | ((ch >> 8) & 0xff);
-            m_u16be_chardata[i] = ch2;
-        }
+        std::ranges::transform(
+            m_u16le_chardata, std::back_inserter(m_u16be_chardata), [](char16_t ch) -> char16_t {
+                return ((ch & 0xff) << 8) | ((ch >> 8) & 0xff);
+            });
 
-        m_u8_sv  = std::u8string_view(&m_u8_chardata[0], m_u8_chardata.size());
-        m_u16le_sv = std::u16string_view(&m_u16le_chardata[0], m_u16le_chardata.size());
-        m_u16be_sv = std::u16string_view(&m_u16be_chardata[0], m_u16be_chardata.size());
-        m_u32_sv = std::u32string_view(&m_u32_chardata[0], m_u32_chardata.size());
+
+        m_u8_sv    = std::u8string_view(m_u8_chardata.begin(), m_u8_chardata.end());
+        m_u16le_sv = std::u16string_view(m_u16le_chardata.begin(), m_u16le_chardata.end());
+        m_u16be_sv = std::u16string_view(m_u16be_chardata.begin(), m_u16be_chardata.end());
+        m_u32_sv   = std::u32string_view(m_u32_chardata.begin(), m_u32_chardata.end());
 
         m_u8_byte_data = std::as_bytes(std::span(m_u8_chardata.begin(), m_u8_chardata.end()));
         m_u16le_byte_data =

--- a/src/libraries/filesystem/include/m/filesystem/filesystem.h
+++ b/src/libraries/filesystem/include/m/filesystem/filesystem.h
@@ -16,6 +16,7 @@
 
 #include <m/byte_streams/byte_streams.h>
 
+#include "filesystem_loadstore.h"
 #include "filesystem_objects.h"
 #include "filesystem_paths.h"
 

--- a/src/libraries/filesystem/include/m/filesystem/filesystem_loadstore.h
+++ b/src/libraries/filesystem/include/m/filesystem/filesystem_loadstore.h
@@ -27,9 +27,37 @@ namespace m
         load(std::filesystem::path const& p, std::error_code& ec);
 
         void
-        store(std::filesystem::path const& p, std::span<std::byte const> s);
+        store_dynamic(std::filesystem::path const&                    p,
+                      std::span<std::byte const, std::dynamic_extent> s);
+
+        template <std::size_t Extent>
+        void
+        store(std::filesystem::path const& p, std::span<std::byte const, Extent> s)
+        {
+            if constexpr (Extent == std::dynamic_extent)
+                store_dynamic(p, s);
+            else
+                store_dynamic(p,
+                              std::span<std::byte const, std::dynamic_extent>(s.data(), s.size()));
+        }
+
 
         void
-        store(std::filesystem::path const& p, std::span<std::byte const> s, std::error_code& ec);
+        store_dynamic(std::filesystem::path const&                    p,
+                      std::span<std::byte const, std::dynamic_extent> s,
+                      std::error_code&                                ec);
+
+        template <std::size_t Extent>
+        void
+        store(std::filesystem::path const&       p,
+              std::span<std::byte const, Extent> s,
+              std::error_code&                   ec)
+        {
+            if constexpr (Extent == std::dynamic_extent)
+                store_dynamic(p, s, ec);
+            else
+                store_dynamic(
+                    p, std::span<std::byte const, std::dynamic_extent>(s.data(), s.size()), ec);
+        }
     } // namespace filesystem
 } // namespace m

--- a/src/libraries/filesystem/src/loadstore.cpp
+++ b/src/libraries/filesystem/src/loadstore.cpp
@@ -104,7 +104,7 @@ namespace m::filesystem
     }
 
     void
-    store(std::filesystem::path const& path, std::span<std::byte> const& data)
+    store_dynamic(std::filesystem::path const& path, std::span<std::byte const, std::dynamic_extent> data)
     {
         auto const fp = std::fopen(path.c_str(), "wb");
         if (!fp)
@@ -129,7 +129,7 @@ namespace m::filesystem
     }
 
     void
-    store(std::filesystem::path const& path, std::span<std::byte> const& data, std::error_code& ec)
+    store_dynamic(std::filesystem::path const& path, std::span<std::byte const, std::dynamic_extent> data, std::error_code& ec)
     {
         auto const fp = std::fopen(path.c_str(), "wb");
         if (!fp)

--- a/src/libraries/filesystem/src/windows_loadstore.cpp
+++ b/src/libraries/filesystem/src/windows_loadstore.cpp
@@ -40,189 +40,186 @@ namespace
     };
 } // namespace
 
-namespace m::filesystem
+std::vector<std::byte>
+m::filesystem::load(std::filesystem::path const& path)
 {
-    std::vector<std::byte>
-    load(std::filesystem::path const& path)
+    unique_hfile file{::CreateFileW(path.c_str(),
+                                    GENERIC_READ,
+                                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                    nullptr,
+                                    OPEN_EXISTING,
+                                    0,
+                                    nullptr)};
+    if (file.get() == INVALID_HANDLE_VALUE)
+        throw_last_win32_error();
+
+    FILE_STANDARD_INFO fsi{};
+
+    if (!::GetFileInformationByHandleEx(file.get(), FileStandardInfo, &fsi, sizeof(fsi)))
+        throw_last_win32_error();
+
+    uint64_t               fileSize = fsi.EndOfFile.QuadPart;
+    std::vector<std::byte> result(fileSize);
+    auto                   outIterator = result.begin();
+    auto const             bytesToRead = static_cast<DWORD>(std::min(1ull << 20, fileSize));
+
+    for (;;)
     {
-        unique_hfile file{::CreateFileW(path.c_str(),
-                                             GENERIC_READ,
-                                             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                                             nullptr,
-                                             OPEN_EXISTING,
-                                             0,
-                                             nullptr)};
-        if (file.get() == INVALID_HANDLE_VALUE)
+        DWORD bytesRead{};
+        if (!::ReadFile(file.get(), &*outIterator, bytesToRead, &bytesRead, nullptr))
             throw_last_win32_error();
 
-        FILE_STANDARD_INFO fsi{};
+        if (bytesRead == 0)
+            break;
 
-        if (!::GetFileInformationByHandleEx(file.get(), FileStandardInfo, &fsi, sizeof(fsi)))
-            throw_last_win32_error();
-
-        uint64_t               fileSize = fsi.EndOfFile.QuadPart;
-        std::vector<std::byte> result(fileSize);
-        auto                   outIterator = result.begin();
-        auto const             bytesToRead = static_cast<DWORD>(std::min(1ull << 20, fileSize));
-
-        for (;;)
-        {
-            DWORD bytesRead{};
-            if (!::ReadFile(file.get(), &*outIterator, bytesToRead, &bytesRead, nullptr))
-                throw_last_win32_error();
-
-            if (bytesRead == 0)
-                break;
-
-            outIterator += bytesRead;
-        }
-
-        return result;
+        outIterator += bytesRead;
     }
 
-    std::optional<std::vector<std::byte>>
-    load(std::filesystem::path const& path, std::error_code& ec)
+    return result;
+}
+
+std::optional<std::vector<std::byte>>
+m::filesystem::load(std::filesystem::path const& path, std::error_code& ec)
+{
+    unique_hfile file{::CreateFileW(path.c_str(),
+                                    GENERIC_READ,
+                                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                    nullptr,
+                                    OPEN_EXISTING,
+                                    0,
+                                    nullptr)};
+    if (file.get() == INVALID_HANDLE_VALUE)
     {
-        unique_hfile file{::CreateFileW(path.c_str(),
-                                             GENERIC_READ,
-                                             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                                             nullptr,
-                                             OPEN_EXISTING,
-                                             0,
-                                             nullptr)};
-        if (file.get() == INVALID_HANDLE_VALUE)
+        ec = get_last_win32_error();
+        return std::nullopt;
+    }
+
+    FILE_STANDARD_INFO fsi{};
+
+    if (!::GetFileInformationByHandleEx(file.get(), FileStandardInfo, &fsi, sizeof(fsi)))
+    {
+        ec = get_last_win32_error();
+        return std::nullopt;
+    }
+
+    uint64_t               fileSize = fsi.EndOfFile.QuadPart;
+    std::vector<std::byte> result(fileSize);
+    auto                   outIterator = result.begin();
+    auto const             bytesToRead = static_cast<DWORD>((std::min)(1ull << 20, fileSize));
+
+    for (;;)
+    {
+        DWORD bytesRead{};
+        if (!::ReadFile(file.get(), &*outIterator, bytesToRead, &bytesRead, nullptr))
         {
             ec = get_last_win32_error();
             return std::nullopt;
         }
 
-        FILE_STANDARD_INFO fsi{};
+        if (bytesRead == 0)
+            break;
 
-        if (!::GetFileInformationByHandleEx(file.get(), FileStandardInfo, &fsi, sizeof(fsi)))
-        {
-            ec = get_last_win32_error();
-            return std::nullopt;
-        }
-
-        uint64_t               fileSize = fsi.EndOfFile.QuadPart;
-        std::vector<std::byte> result(fileSize);
-        auto                   outIterator = result.begin();
-        auto const             bytesToRead = static_cast<DWORD>((std::min)(1ull << 20, fileSize));
-
-        for (;;)
-        {
-            DWORD bytesRead{};
-            if (!::ReadFile(file.get(), &*outIterator, bytesToRead, &bytesRead, nullptr))
-            {
-                ec = get_last_win32_error();
-                return std::nullopt;
-            }
-
-            if (bytesRead == 0)
-                break;
-
-            outIterator += bytesRead;
-        }
-
-        return result;
+        outIterator += bytesRead;
     }
 
-    void
-    store(std::filesystem::path const& path, std::span<std::byte> const& data, std::error_code& ec)
+    return result;
+}
+
+void
+m::filesystem::store_dynamic(std::filesystem::path const&                    path,
+                             std::span<std::byte const, std::dynamic_extent> data,
+                             std::error_code&                                ec)
+{
+    //
+    // It's kind of too bad we can't do some cool transactional filesystem
+    // magic
+    //
+    unique_hfile file{::CreateFileW(path.c_str(),
+                                    GENERIC_WRITE,
+                                    0, // FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                    nullptr,
+                                    CREATE_ALWAYS, // vs. CREATE_NEW
+                                    0,
+                                    nullptr)};
+    if (file.get() == INVALID_HANDLE_VALUE)
+    {
+        ec = get_last_win32_error();
+        return;
+    }
+
+    std::size_t offset{};
+    std::size_t remainingBytes{data.size_bytes()};
+
+    while (offset < data.size())
     {
         //
-        // It's kind of too bad we can't do some cool transactional filesystem
-        // magic
+        // arbitrary, but must be less than the maximum value a DWORD can
+        // hold since that's the largest that WriteFile / WriteFileEx
+        // can do. Perhaps there are other limits further down the I/O
+        // stack, no need to challenge them. In practice, buffered writes
+        // above 64kb at a time tend to suffice to keep the wasted time
+        // in the noise range unless you're in a very high i/o scenario,
+        // in which case you should not be using a synchronous API like
+        // this one.
         //
-        unique_hfile file{
-            ::CreateFileW(path.c_str(),
-                          GENERIC_WRITE,
-                          0, // FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                          nullptr,
-                          CREATE_ALWAYS, // vs. CREATE_NEW
-                          0,
-                          nullptr)};
-        if (file.get() == INVALID_HANDLE_VALUE)
+        // If a Store variant is implemented that is async aware, it
+        // perhaps should be smarter or tunable.
+        //
+        constexpr std::size_t writeChunkSize = 1ull << 20;
+        static_assert(writeChunkSize < (std::numeric_limits<DWORD>::max)());
+        DWORD bytesToWrite = m::to<DWORD>(std::min<std::size_t>(1ull << 20, remainingBytes));
+        DWORD bytesWritten{};
+        if (!::WriteFile(file.get(), &data[offset], bytesToWrite, &bytesWritten, nullptr))
         {
             ec = get_last_win32_error();
             return;
         }
 
-        std::size_t offset{};
-        std::size_t remainingBytes{data.size_bytes()};
-
-        while (offset < data.size())
-        {
-            //
-            // arbitrary, but must be less than the maximum value a DWORD can
-            // hold since that's the largest that WriteFile / WriteFileEx
-            // can do. Perhaps there are other limits further down the I/O
-            // stack, no need to challenge them. In practice, buffered writes
-            // above 64kb at a time tend to suffice to keep the wasted time
-            // in the noise range unless you're in a very high i/o scenario,
-            // in which case you should not be using a synchronous API like
-            // this one.
-            //
-            // If a Store variant is implemented that is async aware, it
-            // perhaps should be smarter or tunable.
-            //
-            constexpr std::size_t writeChunkSize = 1ull << 20;
-            static_assert(writeChunkSize < (std::numeric_limits<DWORD>::max)());
-            DWORD bytesToWrite = m::to<DWORD>(std::min<std::size_t>(1ull << 20, remainingBytes));
-            DWORD bytesWritten{};
-            if (!::WriteFile(file.get(), &data[offset], bytesToWrite, &bytesWritten, nullptr))
-            {
-                ec = get_last_win32_error();
-                return;
-            }
-
-            offset += bytesWritten;
-            remainingBytes -= bytesWritten;
-        }
+        offset += bytesWritten;
+        remainingBytes -= bytesWritten;
     }
+}
 
-    void
-    store(std::filesystem::path const& path, std::span<std::byte> const& data)
+void
+m::filesystem::store_dynamic(std::filesystem::path const&                    path,
+                             std::span<std::byte const, std::dynamic_extent> data)
+{
+    unique_hfile file{::CreateFileW(path.c_str(),
+                                    GENERIC_WRITE,
+                                    0, // FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                    nullptr,
+                                    CREATE_ALWAYS, // vs. CREATE_NEW
+                                    0,
+                                    nullptr)};
+    if (file.get() == INVALID_HANDLE_VALUE)
+        throw_last_win32_error();
+
+    std::size_t offset{};
+    std::size_t remainingBytes{data.size_bytes()};
+
+    while (offset < data.size())
     {
-        unique_hfile file{
-            ::CreateFileW(path.c_str(),
-                          GENERIC_WRITE,
-                          0, // FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                          nullptr,
-                          CREATE_ALWAYS, // vs. CREATE_NEW
-                          0,
-                          nullptr)};
-        if (file.get() == INVALID_HANDLE_VALUE)
+        //
+        // arbitrary, but must be less than the maximum value a DWORD can
+        // hold since that's the largest that WriteFile / WriteFileEx
+        // can do. Perhaps there are other limits further down the I/O
+        // stack, no need to challenge them. In practice, buffered writes
+        // above 64kb at a time tend to suffice to keep the wasted time
+        // in the noise range unless you're in a very high i/o scenario,
+        // in which case you should not be using a synchronous API like
+        // this one.
+        //
+        // If a Store variant is implemented that is async aware, it
+        // perhaps should be smarter or tunable.
+        //
+        constexpr std::size_t writeChunkSize = 1ull << 20;
+        static_assert(writeChunkSize < (std::numeric_limits<DWORD>::max)());
+        DWORD bytesToWrite = m::to<DWORD>(std::min<std::size_t>(1ull << 20, remainingBytes));
+        DWORD bytesWritten{};
+        if (!::WriteFile(file.get(), &data[offset], bytesToWrite, &bytesWritten, nullptr))
             throw_last_win32_error();
 
-        std::size_t offset{};
-        std::size_t remainingBytes{data.size_bytes()};
-
-        while (offset < data.size())
-        {
-            //
-            // arbitrary, but must be less than the maximum value a DWORD can
-            // hold since that's the largest that WriteFile / WriteFileEx
-            // can do. Perhaps there are other limits further down the I/O
-            // stack, no need to challenge them. In practice, buffered writes
-            // above 64kb at a time tend to suffice to keep the wasted time
-            // in the noise range unless you're in a very high i/o scenario,
-            // in which case you should not be using a synchronous API like
-            // this one.
-            //
-            // If a Store variant is implemented that is async aware, it
-            // perhaps should be smarter or tunable.
-            //
-            constexpr std::size_t writeChunkSize = 1ull << 20;
-            static_assert(writeChunkSize < (std::numeric_limits<DWORD>::max)());
-            DWORD bytesToWrite = m::to<DWORD>(std::min<std::size_t>(1ull << 20, remainingBytes));
-            DWORD bytesWritten{};
-            if (!::WriteFile(file.get(), &data[offset], bytesToWrite, &bytesWritten, nullptr))
-                throw_last_win32_error();
-
-            offset += bytesWritten;
-            remainingBytes -= bytesWritten;
-        }
+        offset += bytesWritten;
+        remainingBytes -= bytesWritten;
     }
-
-} // namespace m::filesystem
+}

--- a/src/libraries/filesystem/test/CMakeLists.txt
+++ b/src/libraries/filesystem/test/CMakeLists.txt
@@ -1,2 +1,26 @@
 cmake_minimum_required(VERSION 3.23)
 
+if(M_BUILD_TESTS)
+    include(GoogleTest)
+
+    add_executable(test_filesystem
+        exercise_store.cpp
+    )
+
+    target_link_libraries(
+        test_filesystem
+        m_filesystem
+        GTest::gtest_main
+    )
+
+    enable_testing()
+
+    gtest_discover_tests(test_filesystem)
+
+    list(APPEND m_installation_targets
+        test_filesystem
+    )
+
+    set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)
+
+endif()

--- a/src/libraries/filesystem/test/exercise_store.cpp
+++ b/src/libraries/filesystem/test/exercise_store.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <span>
+#include <string_view>
+
+#include <m/filesystem/filesystem.h>
+
+using namespace std::string_view_literals;
+
+TEST(store, first)
+{
+    // No test asserts, just execution.
+    auto           p        = m::filesystem::make_path("temporary_file");
+    constexpr auto contents = "Hello there filesystem!\n"sv;
+    auto           bytes    = std::as_bytes(std::span(contents.begin(), contents.end()));
+
+    m::filesystem::store(p, bytes);
+
+    std::filesystem::remove(p);
+}
+

--- a/src/libraries/strings/test/test_data.h
+++ b/src/libraries/strings/test/test_data.h
@@ -3,8 +3,10 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
+#include <ranges>
 #include <string_view>
 #include <vector>
 
@@ -17,18 +19,15 @@ struct utf_data_set
         m_u16le_chardata(utf16data.begin(), utf16data.end()),
         m_u32_chardata(utf32data.begin(), utf32data.end())
     {
-        m_u16be_chardata.resize(m_u16le_chardata.size());
-        for (std::size_t i = 0; i < m_u16le_chardata.size(); i++)
-        {
-            char16_t ch = m_u16le_chardata[i];
-            char16_t ch2 = ((ch & 0xff) << 8) | ((ch >> 8) & 0xff);
-            m_u16be_chardata[i] = ch2;
-        }
+        std::ranges::transform(
+            m_u16le_chardata, std::back_inserter(m_u16be_chardata), [](char16_t ch) -> char16_t {
+                return ((ch & 0xff) << 8) | ((ch >> 8) & 0xff);
+            });
 
-        m_u8_sv  = std::u8string_view(&m_u8_chardata[0], m_u8_chardata.size());
-        m_u16le_sv = std::u16string_view(&m_u16le_chardata[0], m_u16le_chardata.size());
-        m_u16be_sv = std::u16string_view(&m_u16be_chardata[0], m_u16be_chardata.size());
-        m_u32_sv = std::u32string_view(&m_u32_chardata[0], m_u32_chardata.size());
+        m_u8_sv    = std::u8string_view(m_u8_chardata.begin(), m_u8_chardata.end());
+        m_u16le_sv = std::u16string_view(m_u16le_chardata.begin(), m_u16le_chardata.end());
+        m_u16be_sv = std::u16string_view(m_u16be_chardata.begin(), m_u16be_chardata.end());
+        m_u32_sv   = std::u32string_view(m_u32_chardata.begin(), m_u32_chardata.end());
 
         m_u8_byte_data = std::as_bytes(std::span(m_u8_chardata.begin(), m_u8_chardata.end()));
         m_u16le_byte_data =

--- a/src/libraries/utf/test/test_data.h
+++ b/src/libraries/utf/test/test_data.h
@@ -17,18 +17,16 @@ struct utf_data_set
         m_u16le_chardata(utf16data.begin(), utf16data.end()),
         m_u32_chardata(utf32data.begin(), utf32data.end())
     {
-        m_u16be_chardata.resize(m_u16le_chardata.size());
-        for (std::size_t i = 0; i < m_u16le_chardata.size(); i++)
-        {
-            char16_t ch         = m_u16le_chardata[i];
-            char16_t ch2        = ((ch & 0xff) << 8) | ((ch >> 8) & 0xff);
-            m_u16be_chardata[i] = ch2;
-        }
+        std::ranges::transform(
+            m_u16le_chardata, std::back_inserter(m_u16be_chardata), [](char16_t ch) -> char16_t {
+                return ((ch & 0xff) << 8) | ((ch >> 8) & 0xff);
+            });
 
-        m_u8_sv    = std::u8string_view(&m_u8_chardata[0], m_u8_chardata.size());
-        m_u16le_sv = std::u16string_view(&m_u16le_chardata[0], m_u16le_chardata.size());
-        m_u16be_sv = std::u16string_view(&m_u16be_chardata[0], m_u16be_chardata.size());
-        m_u32_sv   = std::u32string_view(&m_u32_chardata[0], m_u32_chardata.size());
+
+        m_u8_sv    = std::u8string_view(m_u8_chardata.begin(), m_u8_chardata.end());
+        m_u16le_sv = std::u16string_view(m_u16le_chardata.begin(), m_u16le_chardata.end());
+        m_u16be_sv = std::u16string_view(m_u16be_chardata.begin(), m_u16be_chardata.end());
+        m_u32_sv   = std::u32string_view(m_u32_chardata.begin(), m_u32_chardata.end());
 
         m_u8_byte_data = std::as_bytes(std::span(m_u8_chardata.begin(), m_u8_chardata.end()));
         m_u16le_byte_data =


### PR DESCRIPTION
Fix m::filesystem::store's exposed static library API so that the part that's separately compiled is only a particular variant of std::span.

Fix the test data for multibyte data etc to not generate exceptions on debug msvc builds during initialization.

Add a test case to call store.
