### PR TITLE
Enable m::to<std::string>(std::filesystem::path) and other string types

### DIFF
--- a/src/libraries/filesystem/src/seekable_input_file.cpp
+++ b/src/libraries/filesystem/src/seekable_input_file.cpp
@@ -133,7 +133,7 @@ m::filesystem_impl::seekable_input_file::seek_to(io::position_t p)
     // ("long" is relevant here because it's the "offset" parameter to std::fseek().)
     //
 
-    if (p < std::numeric_limits<long>::max())
+    if (p < (std::numeric_limits<long>::max)())
     {
         // The simple case.
         seek(m::to<long>(std::to_underlying(p)), SEEK_SET);
@@ -145,10 +145,10 @@ m::filesystem_impl::seekable_input_file::seek_to(io::position_t p)
     {
         long offset{};
 
-        if (p < std::numeric_limits<long>::max())
+        if (p < (std::numeric_limits<long>::max)())
             offset = m::to<long>(std::to_underlying(p));
         else
-            offset = std::numeric_limits<long>::max();
+            offset = (std::numeric_limits<long>::max)();
 
         seek(offset, SEEK_CUR);
 

--- a/src/libraries/filesystem/src/seekable_output_file.cpp
+++ b/src/libraries/filesystem/src/seekable_output_file.cpp
@@ -122,7 +122,7 @@ m::filesystem_impl::seekable_output_file::seek_to(io::position_t p)
     // ("long" is relevant here because it's the "offset" parameter to std::fseek().)
     //
 
-    if (p < std::numeric_limits<long>::max())
+    if (p < (std::numeric_limits<long>::max)())
     {
         // The simple case.
         seek(m::to<long>(std::to_underlying(p)), SEEK_SET);
@@ -134,10 +134,10 @@ m::filesystem_impl::seekable_output_file::seek_to(io::position_t p)
     {
         long offset{};
 
-        if (p < std::numeric_limits<long>::max())
+        if (p < (std::numeric_limits<long>::max)())
             offset = m::to<long>(std::to_underlying(p));
         else
-            offset = std::numeric_limits<long>::max();
+            offset = (std::numeric_limits<long>::max)();
 
         seek(offset, SEEK_CUR);
 

--- a/src/libraries/filesystem/test/CMakeLists.txt
+++ b/src/libraries/filesystem/test/CMakeLists.txt
@@ -4,6 +4,7 @@ if(M_BUILD_TESTS)
     include(GoogleTest)
 
     add_executable(test_filesystem
+        exercise_path_casts.cpp
         exercise_store.cpp
     )
 

--- a/src/libraries/filesystem/test/exercise_path_casts.cpp
+++ b/src/libraries/filesystem/test/exercise_path_casts.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <span>
+#include <string_view>
+
+#include <m/filesystem/filesystem.h>
+
+using namespace std::string_view_literals;
+
+TEST(path_casts, string)
+{
+    // No test asserts, just execution.
+    auto p = m::filesystem::make_path("temporary_file");
+    auto s = m::to<std::string>(p);
+}
+
+TEST(path_casts, wstring)
+{
+    // No test asserts, just execution.
+    auto p = m::filesystem::make_path("temporary_file");
+    auto s = m::to<std::wstring>(p);
+}
+
+
+TEST(path_casts, u8string)
+{
+    // No test asserts, just execution.
+    auto p = m::filesystem::make_path("temporary_file");
+    auto s = m::to<std::u8string>(p);
+}
+
+TEST(path_casts, u16string)
+{
+    // No test asserts, just execution.
+    auto p = m::filesystem::make_path("temporary_file");
+    auto s = m::to<std::u16string>(p);
+}
+
+TEST(path_casts, u32string)
+{
+    // No test asserts, just execution.
+    auto p = m::filesystem::make_path("temporary_file");
+    auto s = m::to<std::u32string>(p);
+}

--- a/src/libraries/pe/include/m/pe/image_import_descriptor.h
+++ b/src/libraries/pe/include/m/pe/image_import_descriptor.h
@@ -97,10 +97,10 @@ namespace m
                 lfrc.load_into(iid.m_import_address_table,
                                base_offset + k_offset_import_address_table);
 
-                if (iid.m_name != 0)
+                if (iid.m_name != m::pe::rva_t{0})
                     iid.m_name_string = s->load_ascii(iid.m_name);
 
-                if (iid.m_import_name_table != 0)
+                if (iid.m_import_name_table != m::pe::rva_t{0})
                 {
                     switch (image_magic)
                     {


### PR DESCRIPTION
Adds conversions from std::filesystem::path to the common C++ string types for convenience and fluency

