### PR TITLE
Fix timer lifetime issue

### DIFF
--- a/src/Windows/libraries/debugging/include/m/debugging/dbg_format.h
+++ b/src/Windows/libraries/debugging/include/m/debugging/dbg_format.h
@@ -193,9 +193,10 @@ namespace m
         *iter++ = 0;
 
         OutputDebugStringA(buffer.data());
+        OutputDebugStringA("\n");
 
         if (dbg_format_details::try_allocate_std_out_message())
-            std::cout << buffer.data();
+            std::cout << buffer.data() << '\n';
     }
 
     template <int = 0>
@@ -209,9 +210,10 @@ namespace m
         *iter++ = 0;
 
         OutputDebugStringW(buffer.data());
+        OutputDebugStringW(L"\n");
 
         if (dbg_format_details::try_allocate_std_out_message())
-            std::wcout << buffer.data();
+            std::wcout << buffer.data() << L'\n';
     }
 
     template <typename... Types>
@@ -243,9 +245,10 @@ namespace m
             *iter++ = 0;
 
             OutputDebugStringA(buffer.data());
+            OutputDebugStringA("\n");
 
             if (dbg_format_details::try_allocate_std_out_message())
-                std::cout << buffer.data();
+                std::cout << buffer.data() << '\n';
         }
         else
         {
@@ -258,9 +261,10 @@ namespace m
             *iter++ = L'\0';
 
             OutputDebugStringW(buffer.data());
+            OutputDebugStringW(L"\n");
 
             if (dbg_format_details::try_allocate_std_out_message())
-                std::wcout << buffer.data();
+                std::wcout << buffer.data() << L'\n';
         }
     }
 } // namespace m

--- a/src/libraries/threadpool/src/platforms/windows/threadpool_timer_impl.h
+++ b/src/libraries/threadpool/src/platforms/windows/threadpool_timer_impl.h
@@ -131,8 +131,8 @@ namespace m::threadpool_impl
         task_type          m_task;
         duration           m_duration;
         std::atomic<bool>  m_cancel_requested{false};
+        std::atomic<bool>  m_done{true};
         bool               m_cancelled{false};
-        bool               m_done{true};
         bool               m_started{false};
     };
 


### PR DESCRIPTION
Realized overnight that destroying a timer object would not synchronize with pending or executing timer callbacks.
fixed this.
also fixed the windows dbg_format support to write the newlines instead of making callers do it. yes its asymmetric with what std::format() might do, now it's like println or such but its easier to use. This is just for debug output.
add unit test to verify