### PR TITLE
Remove use of ReadDirectoryChangesExW

### DIFF
--- a/src/libraries/filesystem/src/platforms/windows/directory_watcher.h
+++ b/src/libraries/filesystem/src/platforms/windows/directory_watcher.h
@@ -144,14 +144,14 @@ namespace m::filesystem_impl::platform_specific
         {
         public:
             ptp_io() = default;
-            ptp_io(ptp_io&& other)
+            ptp_io(ptp_io&& other) noexcept
             {
                 using std::swap;
                 swap(m_p, other.m_p);
             }
             ptp_io(ptp_io const& other) = delete;
             ptp_io&
-            operator=(ptp_io&& other)
+            operator=(ptp_io&& other) noexcept
             {
                 using std::swap;
                 swap(m_p, other.m_p);


### PR DESCRIPTION
Remove the use of ReadDirectoryChangesExW
Improve threadpool timer tests to deal with more variance

The primary client of m, as it turns out, has to run on Windows Server 2016 which does not have ReadDirectoryChangesExW.

I hate retracting stuff like this but it's an unmovable object.

Considered making it optional via GetModuleHandle/GetProcAddress but it just didn't seem worth it since the code isn't using the extra data from the extended information yet.

The threadpool timer tests were outside the variance checks on my dev machine, the 100ms waits were hitting up to 25ms late. This is perhaps surprising but not the fault of the code. I mean perhaps it is because it specifies a nonzero window but really the requirement is to wait, not to be a realtime scheduler.

Adding options for quality of service to the timer object probably needs to happen at some point.
