### PR TITLE
Add os_thread_id() to tracing event context since std::thread::id is opaque

### DIFF
--- a/src/libraries/tracing/include/m/tracing/event_context.h
+++ b/src/libraries/tracing/include/m/tracing/event_context.h
@@ -29,7 +29,8 @@ namespace m
             {
                 using std::swap;
 
-                swap(l.m_process_id, r.m_process_id);
+                swap(l.m_os_process_id, r.m_os_process_id);
+                swap(l.m_os_thread_id, r.m_os_thread_id);
                 swap(l.m_thread_id, r.m_thread_id);
                 swap(l.m_time_point, r.m_time_point);
             }
@@ -38,9 +39,15 @@ namespace m
             current();
 
             constexpr uint64_t
-            process_id() const
+            os_process_id() const
             {
-                return m_process_id;
+                return m_os_process_id;
+            }
+
+            constexpr uint64_t
+            os_thread_id() const
+            {
+                return m_os_thread_id;
             }
 
             std::thread::id
@@ -53,8 +60,9 @@ namespace m
             }
 
         protected:
-            uint64_t        m_process_id;
             std::thread::id m_thread_id;
+            uint64_t        m_os_process_id;
+            uint64_t        m_os_thread_id;
             utc_time_point  m_time_point;
         };
 

--- a/src/libraries/tracing/src/cout_sink.cpp
+++ b/src/libraries/tracing/src/cout_sink.cpp
@@ -61,8 +61,8 @@ namespace m::tracing
                     auto it = safe_array_iterator(buffer, 0);
                     auto itend = std::format_to(it,
                                                 L"[p({}) t({}) @ {}Z] {}\n",
-                                                msg->m_event_context.process_id(),
-                                                msg->m_event_context.thread_id(),
+                                                msg->m_event_context.os_process_id(),
+                                                msg->m_event_context.os_thread_id(),
                                                 msg->m_event_context.time_point(),
                                                 msg->view());
 

--- a/src/libraries/tracing/src/event_context.cpp
+++ b/src/libraries/tracing/src/event_context.cpp
@@ -18,20 +18,24 @@
 
 namespace m::tracing
 {
-    event_context::event_context() noexcept: m_process_id{}, m_thread_id{}, m_time_point{} {}
+    event_context::event_context() noexcept:
+        m_thread_id{}, m_os_process_id{}, m_os_thread_id{}, m_time_point{}
+    {}
 
     event_context::event_context(event_context const& other) noexcept:
-        m_process_id(other.m_process_id),
         m_thread_id(other.m_thread_id),
+        m_os_process_id(other.m_os_process_id),
+        m_os_thread_id(other.m_os_thread_id),
         m_time_point(other.m_time_point)
     {}
 
     event_context&
     event_context::operator=(event_context const& other) noexcept
     {
-        m_process_id = other.m_process_id;
-        m_thread_id  = other.m_thread_id;
-        m_time_point = other.m_time_point;
+        m_thread_id     = other.m_thread_id;
+        m_os_process_id = other.m_os_process_id;
+        m_os_thread_id  = other.m_os_thread_id;
+        m_time_point    = other.m_time_point;
         return *this;
     }
 
@@ -47,10 +51,13 @@ namespace m::tracing
         event_context retval{};
 
 #ifdef WIN32
-        retval.m_process_id = ::GetCurrentProcessId();
+        retval.m_os_process_id = ::GetCurrentProcessId();
+        retval.m_os_thread_id  = ::GetCurrentThreadId();
 #else
-        retval.m_process_id = getpid();
+        retval.m_os_process_id = getpid();
+        retval.m_os_thread_id  = gettid();
 #endif
+
         retval.m_thread_id  = std::this_thread::get_id();
         retval.m_time_point = std::chrono::utc_clock::now();
         return retval;


### PR DESCRIPTION
It turns out that std::thread::id is opaque which makes for a less than great experience for logging where we need the 32-bit thread id on windows.

In practice, it almost certainly _is_ the 32 bit thread id, but we are attempting to not subvert the type system like that. So instead in this change, we are changing the name of process_id to os_process_id and adding os_thread_id to match.
