### PR TITLE
Add event_kind to message instead of dropping it after using it for f…

### DIFF
--- a/src/libraries/tracing/include/m/tracing/event_context.h
+++ b/src/libraries/tracing/include/m/tracing/event_context.h
@@ -61,8 +61,8 @@ namespace m
 
         protected:
             std::thread::id m_thread_id;
-            uint64_t        m_os_process_id;
-            uint64_t        m_os_thread_id;
+            uint32_t        m_os_process_id;
+            uint32_t        m_os_thread_id;
             utc_time_point  m_time_point;
         };
 

--- a/src/libraries/tracing/include/m/tracing/event_kind.h
+++ b/src/libraries/tracing/include/m/tracing/event_kind.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <format>
 
 namespace m
 {
@@ -19,3 +20,43 @@ namespace m
         };
     } // namespace tracing
 } // namespace m
+
+template <typename CharT>
+struct std::formatter<m::tracing::event_kind, CharT>
+{
+    template <typename ParseContext>
+    constexpr decltype(auto)
+    parse(ParseContext& ctx)
+    {
+        auto       it  = ctx.begin();
+        auto const end = ctx.end();
+
+        if (it != end && *it != '}')
+            throw std::format_error("Invalid format string");
+
+        return it;
+    }
+
+    template <typename FormatContext>
+    FormatContext::iterator
+    format(m::tracing::event_kind kind, FormatContext& ctx) const
+    {
+        auto out = ctx.out();
+
+        string_view kind_sv = "<unmapped>"sv;
+
+        switch (kind)
+        {
+            case m::tracing::event_kind::critical: kind_sv = "critical"sv; break;
+            case m::tracing::event_kind::error: kind_sv = "error"sv; break;
+            case m::tracing::event_kind::information: kind_sv = "information"sv; break;
+            case m::tracing::event_kind::tracing: kind_sv = "tracing"sv; break;
+            case m::tracing::event_kind::verbose: kind_sv = "verbose"sv; break;
+            default: kind_sv = "<unmapped>"sv; break;
+        }
+
+        out = std::format_to(out, "{{ m::tracing::event_kind::{} }}", kind_sv);
+
+        return out;
+    }
+};

--- a/src/libraries/tracing/include/m/tracing/message.h
+++ b/src/libraries/tracing/include/m/tracing/message.h
@@ -48,6 +48,9 @@ namespace m
             std::wstring_view
             view();
 
+            event_kind
+            kind() const;
+
             template <typename FormatStringT, typename FormatArgsT>
             void
             format_log(FormatStringT&& fmt, FormatArgsT&& format_args)
@@ -58,7 +61,11 @@ namespace m
                 m_length         = m::try_cast<std::size_t>(diff);
             }
 
+            void
+            kind(event_kind kind);
+
             // private:
+            event_kind                m_event_kind;
             std::size_t               m_length;
             std::array<wchar_t, 4096> m_chars;
             event_context             m_event_context;

--- a/src/libraries/tracing/include/m/tracing/monitor_class.h
+++ b/src/libraries/tracing/include/m/tracing/monitor_class.h
@@ -104,7 +104,7 @@ namespace m
             get_topology_version() const;
 
             envelope
-            reserve_message();
+            reserve_message(event_kind kind);
 
         private:
             std::atomic<topology_version>                                   m_topology_version;

--- a/src/libraries/tracing/include/m/tracing/multiplexor.h
+++ b/src/libraries/tracing/include/m/tracing/multiplexor.h
@@ -54,7 +54,7 @@ namespace m
 
             [[nodiscard]]
             envelope
-            reserve_message();
+            reserve_message(event_kind kind);
 
         private:
             // m_monitor and m_channel_names are not updated after construction

--- a/src/libraries/tracing/include/m/tracing/source.h
+++ b/src/libraries/tracing/include/m/tracing/source.h
@@ -95,7 +95,7 @@ namespace m
             {
                 if (!m_closed && do_test_kind(kind))
                 {
-                    auto qitem = m_multiplexor->reserve_message();
+                    auto qitem = m_multiplexor->reserve_message(kind);
                     qitem.get_message()->format_log(fmt, std::forward<FormatArgsT>(format_args));
                     qitem.get_message()->m_event_context = event_context::current();
                     std::ignore                          = m_multiplexor->on_message(qitem);

--- a/src/libraries/tracing/src/cout_sink.cpp
+++ b/src/libraries/tracing/src/cout_sink.cpp
@@ -58,65 +58,67 @@ namespace m::tracing
 
                 if (msg != nullptr)
                 {
-                    auto it = safe_array_iterator(buffer, 0);
+                    auto it    = safe_array_iterator(buffer, 0);
                     auto itend = std::format_to(it,
-                                                L"[p({}) t({}) @ {}Z] {}\n",
+                                                L"[k{} p({}) t({}) @ {}Z] {}\n",
+                                                msg->kind(),
                                                 msg->m_event_context.os_process_id(),
                                                 msg->m_event_context.os_thread_id(),
                                                 msg->m_event_context.time_point(),
                                                 msg->view());
 
                     std::wcout << std::wstring_view(&*it, &*itend);
+                }
+            }
+
+            if (m_done)
+                break;
+
+            m_message_queue.wait();
+        }
+    }
+
+    bool
+    cout_sink::would_queue(envelope const&)
+    {
+        return true;
+    }
+
+    void
+    cout_sink::register_sink(m::not_null<monitor_class*> monitor)
+    {
+        std::shared_ptr<cout_sink> expected = ms_cout_sink.load(std::memory_order_acquire);
+
+        if (!expected)
+        {
+            for (;;)
+            {
+                auto desired = std::make_shared<cout_sink>(monitor);
+
+                if (ms_cout_sink.compare_exchange_strong(
+                        expected, desired, std::memory_order_acq_rel))
+                    break;
+            }
+
+            expected = ms_cout_sink.load(std::memory_order_acquire);
+        }
+
+        monitor->register_sink(expected);
+    }
+
+    void
+    cout_sink::close()
+    {
+        {
+            auto l = std::unique_lock(m_mutex);
+            if (!m_done)
+            {
+                m_done   = true;
+                m_closed = true;
+                m_message_queue.wake_waiters();
             }
         }
-
-        if (m_done)
-            break;
-
-        m_message_queue.wait();
+        m_thread.join();
     }
-}
-
-bool
-cout_sink::would_queue(envelope const&)
-{
-    return true;
-}
-
-void
-cout_sink::register_sink(m::not_null<monitor_class*> monitor)
-{
-    std::shared_ptr<cout_sink> expected = ms_cout_sink.load(std::memory_order_acquire);
-
-    if (!expected)
-    {
-        for (;;)
-        {
-            auto desired = std::make_shared<cout_sink>(monitor);
-
-            if (ms_cout_sink.compare_exchange_strong(expected, desired, std::memory_order_acq_rel))
-                break;
-        }
-
-        expected = ms_cout_sink.load(std::memory_order_acquire);
-    }
-
-    monitor->register_sink(expected);
-}
-
-void
-cout_sink::close()
-{
-    {
-        auto l = std::unique_lock(m_mutex);
-        if (!m_done)
-        {
-            m_done   = true;
-            m_closed = true;
-            m_message_queue.wake_waiters();
-        }
-    }
-    m_thread.join();
-}
 
 } // namespace m::tracing

--- a/src/libraries/tracing/src/message.cpp
+++ b/src/libraries/tracing/src/message.cpp
@@ -11,6 +11,7 @@ namespace m::tracing
     void
     message::operator=(message const& other)
     {
+        m_event_kind = other.m_event_kind;
         std::copy_n(other.m_chars.begin(), other.m_length, m_chars.begin());
         m_length        = other.m_length;
         m_event_context = other.m_event_context;
@@ -20,6 +21,18 @@ namespace m::tracing
     message::view()
     {
         return std::wstring_view(m_chars.data(), m_length);
+    }
+
+    event_kind
+    message::kind() const
+    {
+        return m_event_kind;
+    }
+
+    void
+    message::kind(event_kind kind)
+    {
+        m_event_kind = kind;
     }
 
 } // namespace m::tracing

--- a/src/libraries/tracing/src/monitor_class.cpp
+++ b/src/libraries/tracing/src/monitor_class.cpp
@@ -32,8 +32,7 @@ namespace m::tracing
         auto it = m_channels.find(name);
         if (it == m_channels.end())
         {
-            auto r = m_channels.emplace(
-                std::make_pair(name, std::make_unique<channel>(name)));
+            auto r = m_channels.emplace(std::make_pair(name, std::make_unique<channel>(name)));
             return r.first->second.get();
         }
 
@@ -67,10 +66,12 @@ namespace m::tracing
     }
 
     envelope
-    monitor_class::reserve_message()
+    monitor_class::reserve_message(event_kind kind)
     {
-        auto l = std::unique_lock(m_mutex);
-        return m_message_queue.dequeue();
+        auto l   = std::unique_lock(m_mutex);
+        auto env = m_message_queue.dequeue(); // don't make env const to allow rvo
+        env.get_message()->kind(kind);
+        return env;
     }
 
     envelope

--- a/src/libraries/tracing/src/multiplexor.cpp
+++ b/src/libraries/tracing/src/multiplexor.cpp
@@ -54,9 +54,9 @@ namespace m::tracing
     }
 
     envelope
-    multiplexor::reserve_message()
+    multiplexor::reserve_message(event_kind kind)
     {
-        return m_monitor->reserve_message();
+        return m_monitor->reserve_message(kind);
     }
 
 } // namespace m::tracing


### PR DESCRIPTION
…iltering.

verify by inspection of trace output to std::cout sink

Also narrowed the process id and thread id to 32 bits to avoid confusion since no platform that I'm aware of actually has IDs that are larger than 32 bits.
