### PR TITLE
Fix the installation of windows_chrono_casts.h

### DIFF
--- a/src/libraries/chrono/include/CMakeLists.txt
+++ b/src/libraries/chrono/include/CMakeLists.txt
@@ -3,3 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 target_sources(m_chrono PUBLIC FILE_SET HEADERS FILES 
     m/chrono/chrono.h
 )
+
+add_subdirectory(Platforms)
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)

--- a/src/libraries/chrono/include/Platforms/Windows/CMakeLists.txt
+++ b/src/libraries/chrono/include/Platforms/Windows/CMakeLists.txt
@@ -3,3 +3,5 @@ cmake_minimum_required(VERSION 3.23)
 target_sources(m_chrono PUBLIC FILE_SET HEADERS FILES
     m/chrono/windows_chrono_casts.h
 )
+
+set(m_installation_targets ${m_installation_targets} PARENT_SCOPE)


### PR DESCRIPTION
Fix the missing add directories for getting windows_chrono_casts.h to be installed.

Really need some pre-release tests to verify this stuff.
