### PR TITLE
Add requirement for C++23 for inplace_vector.h

### DIFF
--- a/src/libraries/inplace_vector/CMakeLists.txt
+++ b/src/libraries/inplace_vector/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.23)
 
 add_library(m_inplace_vector STATIC)
 
+target_compile_features(m_inplace_vector PUBLIC cxx_std_23)
+
 add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(test)

--- a/src/libraries/inplace_vector/include/m/inplace_vector/inplace_vector.h
+++ b/src/libraries/inplace_vector/include/m/inplace_vector/inplace_vector.h
@@ -3,6 +3,14 @@
 
 #pragma once
 
+#include <m/utility/compiler.h>
+
+#ifndef M_HAS_CXX23
+
+#error The inplace_vector.h header requires the C++23 standard or later
+
+#endif
+
 #include <algorithm> // for rotate, equals, move_backwards, ...
 #include <array>
 #include <compare>

--- a/src/libraries/inplace_vector/test/CMakeLists.txt
+++ b/src/libraries/inplace_vector/test/CMakeLists.txt
@@ -7,6 +7,8 @@ if(M_BUILD_TESTS)
         test_inplace_vector.cpp
     )
 
+    target_compile_features(test_inplace_vector PUBLIC cxx_std_23)
+
     target_link_libraries(test_inplace_vector
         m_inplace_vector
         GTest::gtest_main


### PR DESCRIPTION
inplace_vector.h, copied from the proposed inplace_vector implementation includes consteval which requires C++23.

Added requirements for c++23.
