### PR TITLE
Add periodic_timer.h to threadpool library publishing

### DIFF
--- a/src/libraries/threadpool/include/CMakeLists.txt
+++ b/src/libraries/threadpool/include/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.23)
 
 target_sources(m_threadpool PUBLIC FILE_SET HEADERS FILES
+    m/threadpool/periodic_timer.h
     m/threadpool/threadpool.h
     m/threadpool/threadpool_class.h
     m/threadpool/timer.h


### PR DESCRIPTION
yet another missing header forgotten in the last fix
