### PR TITLE
cp_acp: fix bugs in to_string.h and utf16_to_acp_impl, add tests

### DIFF
--- a/src/Windows/libraries/cp_acp/include/m/cp_acp/to_string.h
+++ b/src/Windows/libraries/cp_acp/include/m/cp_acp/to_string.h
@@ -3,112 +3,58 @@
 
 #pragma once
 
-#include <algorithm>
-#include <cstdint>
-#include <iterator>
-#include <numeric>
 #include <optional>
-#include <ranges>
-#include <span>
 #include <string>
 #include <string_view>
-#include <type_traits>
+#include <system_error>
 
-#include <Windows.h>
-
-#include <m/errors/errors.h>
-#include <m/multi_byte/code_page.h>
+#include <m/cp_acp/convert_acp_to.h>
 #include <m/strings/convert.h>
-#include <m/utf/decode.h>
-#include <m/utf/encode.h>
 #include <m/utility/concepts.h>
-#include <m/utility/make_span.h>
-
-#include <m/cp_acp/convert_core.h>
-#include <m/cp_acp/cp_acp.h>
 
 namespace m
 {
-    template <typename TStringish>
-        requires any_stringish<TStringish>
-    void
-    acp_to_string(TStringish&& in, std::string& out)
-    {
-        auto const view =
-            to_basic_string_view_t<stringish_char_type_t<TStringish>>(std::forward<TStringish>(in));
-        acp_to_tstring(view, out);
-    }
+    //
+    // Optional overloads for acp_to_string.  These supplement the non-optional overloads
+    // provided in convert_acp_to.h and propagate std::nullopt when the input is absent.
+    //
 
     template <typename TStringish>
-        requires any_stringish<TStringish>
-    void
-    acp_to_string(TStringish&& in, std::string& out, std::error_code& ec)
-    {
-        auto const view =
-            to_basic_string_view_t<stringish_char_type_t<TStringish>>(std::forward<TStringish>(in));
-        acp_to_tstring(view, out, ec);
-    }
-
-    template <typename TStringish>
-        requires any_stringish<TStringish>
-    std::string
-    acp_to_string(TStringish&& in)
-    {
-        std::string out;
-        auto const  view =
-            to_basic_string_view_t<stringish_char_type_t<TStringish>>(std::forward<TStringish>(in));
-        acp_to_tstring(view, out);
-        return out;
-    }
-
-    template <typename TStringish>
-        requires any_stringish<TStringish>
-    std::string
-    acp_to_string(TStringish&& in, std::error_code& ec)
-    {
-        std::string out;
-        auto const  view =
-            to_basic_string_view_t<stringish_char_type_t<TStringish>>(std::forward<TStringish>(in));
-        acp_to_tstring(view, out.value(), ec);
-        return out;
-    }
-
-    template <typename TStringish>
-        requires any_stringish<TStringish>
+        requires stringish<TStringish, char>
     void
     acp_to_string(std::optional<TStringish> const& in, std::optional<std::string>& out)
     {
-        // Propagate nullopt
         if (!in.has_value())
         {
             out = std::nullopt;
             return;
         }
 
-        auto const view = to_basic_string_view_t<stringish_char_type_t<TStringish>>(in.value());
-        acp_to_tstring(view, out);
+        auto const view = to_basic_string_view_t<char>(in.value());
+        out.emplace();
+        acp_to_basic_string(view, *out);
     }
 
     template <typename TStringish>
-        requires any_stringish<TStringish>
+        requires stringish<TStringish, char>
     void
     acp_to_string(std::optional<TStringish> const& in,
-                  std::optional<std::string>&      out,
-                  std::error_code&                 ec)
+                  std::optional<std::string>&       out,
+                  std::error_code&                  ec)
     {
-        // Propagate nullopt
         if (!in.has_value())
         {
             out = std::nullopt;
             return;
         }
 
-        auto const view = to_basic_string_view_t<stringish_char_type_t<TStringish>>(in.value());
-        acp_to_tstring(view, out.value(), ec);
+        auto const view = to_basic_string_view_t<char>(in.value());
+        out.emplace();
+        acp_to_basic_string(view, *out, ec);
     }
 
     template <typename TStringish>
-        requires any_stringish<TStringish>
+        requires stringish<TStringish, char>
     std::optional<std::string>
     acp_to_string(std::optional<TStringish> const& in)
     {
@@ -116,13 +62,13 @@ namespace m
             return std::nullopt;
 
         std::string out;
-        auto const  view = to_basic_string_view_t<stringish_char_type_t<TStringish>>(in.value());
-        acp_to_tstring(view, out);
+        auto const  view = to_basic_string_view_t<char>(in.value());
+        acp_to_basic_string(view, out);
         return out;
     }
 
     template <typename TStringish>
-        requires any_stringish<TStringish>
+        requires stringish<TStringish, char>
     std::optional<std::string>
     acp_to_string(std::optional<TStringish> const& in, std::error_code& ec)
     {
@@ -130,8 +76,8 @@ namespace m
             return std::nullopt;
 
         std::string out;
-        auto const  view = to_basic_string_view_t<stringish_char_type_t<TStringish>>(in.value());
-        acp_to_tstring(view, out, ec);
+        auto const  view = to_basic_string_view_t<char>(in.value());
+        acp_to_basic_string(view, out, ec);
         return out;
     }
 

--- a/src/Windows/libraries/cp_acp/src/utf16_to_acp.cpp
+++ b/src/Windows/libraries/cp_acp/src/utf16_to_acp.cpp
@@ -26,7 +26,8 @@ namespace
         out.resize_and_overwrite(chars_needed,
                                  [view](auto buffer, auto buffer_size) -> std::size_t {
                                      auto span = m::make_span(buffer, buffer_size);
-                                     return m::utf16_to_acp(view, span);
+                                     m::utf16_to_acp(view, span);
+                                     return span.size();
                                  });
     }
 

--- a/src/Windows/libraries/cp_acp/test/CMakeLists.txt
+++ b/src/Windows/libraries/cp_acp/test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_EXE_NAME test_cp_acp)
 
 add_executable(${TEST_EXE_NAME}
     test_acp_apis.cpp
+    test_acp_extended.cpp
 )
 
 target_compile_features(${TEST_EXE_NAME} PUBLIC ${M_CXX_STD})
@@ -13,6 +14,7 @@ target_compile_features(${TEST_EXE_NAME} PUBLIC ${M_CXX_STD})
 target_link_libraries(
     ${TEST_EXE_NAME}
     m_cast
+    m_cp_acp
     m_math
     m_multi_byte
     m_sstring

--- a/src/Windows/libraries/cp_acp/test/test_acp_extended.cpp
+++ b/src/Windows/libraries/cp_acp/test/test_acp_extended.cpp
@@ -1,0 +1,317 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Extended tests for cp_acp API — covering paths the main test file omits:
+//   * acp_to_string (char → char identity), via value-return and out-param forms
+//   * acp_to_basic_string<char>
+//   * error_code overloads (happy path for all converters)
+//   * empty string inputs
+//   * optional overloads from to_string.h
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include <m/cp_acp/convert.h>
+#include <m/cp_acp/to_string.h>
+#include <m/windows_strings/convert.h>
+
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+// ---------------------------------------------------------------------------
+// acp_to_string (char → char identity)
+// ---------------------------------------------------------------------------
+
+TEST(AcpAPIs_Extended, acp_to_string_value_return)
+{
+    char const* p = "hello";
+    EXPECT_EQ(m::acp_to_string("hello"sv), "hello"s);
+    EXPECT_EQ(m::acp_to_string("hello"s), "hello"s);
+    EXPECT_EQ(m::acp_to_string(p), "hello"s);
+}
+
+TEST(AcpAPIs_Extended, acp_to_string_out_param)
+{
+    std::string out;
+    m::acp_to_string("world"sv, out);
+    EXPECT_EQ(out, "world"s);
+
+    std::string out2;
+    m::acp_to_string("world"s, out2);
+    EXPECT_EQ(out2, "world"s);
+}
+
+TEST(AcpAPIs_Extended, acp_to_string_ec_value_return)
+{
+    std::error_code ec;
+    auto            r = m::acp_to_string("test"sv, ec);
+    EXPECT_FALSE(ec);
+    EXPECT_EQ(r, "test"s);
+}
+
+TEST(AcpAPIs_Extended, acp_to_string_ec_out_param)
+{
+    std::string     out;
+    std::error_code ec;
+    m::acp_to_string("test"sv, out, ec);
+    EXPECT_FALSE(ec);
+    EXPECT_EQ(out, "test"s);
+}
+
+// ---------------------------------------------------------------------------
+// acp_to_basic_string<char>
+// ---------------------------------------------------------------------------
+
+TEST(AcpAPIs_Extended, acp_to_basic_string_char_value_return)
+{
+    EXPECT_EQ(m::acp_to_basic_string<char>("abc"sv), "abc"s);
+    EXPECT_EQ(m::acp_to_basic_string<char>("abc"s), "abc"s);
+    EXPECT_EQ(m::acp_to_basic_string<char>("abc"), "abc"s);
+}
+
+TEST(AcpAPIs_Extended, acp_to_basic_string_char_out_param)
+{
+    std::string out;
+    m::acp_to_basic_string("xyz"sv, out);
+    EXPECT_EQ(out, "xyz"s);
+}
+
+TEST(AcpAPIs_Extended, acp_to_basic_string_char_ec_value_return)
+{
+    std::error_code ec;
+    auto            r = m::acp_to_basic_string<char>("test"sv, ec);
+    EXPECT_FALSE(ec);
+    EXPECT_EQ(r, "test"s);
+}
+
+TEST(AcpAPIs_Extended, acp_to_basic_string_char_ec_out_param)
+{
+    std::string     out;
+    std::error_code ec;
+    m::acp_to_basic_string("test"sv, out, ec);
+    EXPECT_FALSE(ec);
+    EXPECT_EQ(out, "test"s);
+}
+
+// ---------------------------------------------------------------------------
+// Empty string inputs
+// ---------------------------------------------------------------------------
+
+TEST(AcpAPIs_Extended, empty_string_acp_to_string)
+{
+    EXPECT_TRUE(m::acp_to_string(""sv).empty());
+    EXPECT_TRUE(m::acp_to_string(""s).empty());
+
+    std::string out{"nonempty"};
+    m::acp_to_string(""sv, out);
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(AcpAPIs_Extended, empty_string_acp_to_wstring)
+{
+    EXPECT_TRUE(m::acp_to_wstring(""sv).empty());
+
+    std::wstring out{L"nonempty"};
+    m::acp_to_wstring(""sv, out);
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(AcpAPIs_Extended, empty_string_acp_to_u8string)
+{
+    EXPECT_TRUE(m::acp_to_u8string(""sv).empty());
+}
+
+TEST(AcpAPIs_Extended, empty_string_acp_to_u16string)
+{
+    EXPECT_TRUE(m::acp_to_u16string(""sv).empty());
+}
+
+TEST(AcpAPIs_Extended, empty_string_acp_to_u32string)
+{
+    EXPECT_TRUE(m::acp_to_u32string(""sv).empty());
+}
+
+TEST(AcpAPIs_Extended, empty_string_to_acp)
+{
+    EXPECT_TRUE(m::to_acp_string(""sv).empty());
+    EXPECT_TRUE(m::to_acp_string(L""sv).empty());
+    EXPECT_TRUE(m::to_acp_string(u""sv).empty());
+    EXPECT_TRUE(m::to_acp_string(u8""sv).empty());
+}
+
+// ---------------------------------------------------------------------------
+// error_code overloads — other converters (happy path)
+// ---------------------------------------------------------------------------
+
+TEST(AcpAPIs_Extended, acp_to_wstring_ec)
+{
+    {
+        std::wstring    out;
+        std::error_code ec;
+        m::acp_to_wstring("hello"sv, out, ec);
+        EXPECT_FALSE(ec);
+        EXPECT_EQ(out, L"hello"s);
+    }
+    {
+        std::error_code ec;
+        auto            r = m::acp_to_wstring("hello"sv, ec);
+        EXPECT_FALSE(ec);
+        EXPECT_EQ(r, L"hello"s);
+    }
+}
+
+TEST(AcpAPIs_Extended, acp_to_u8string_ec)
+{
+    {
+        std::u8string   out;
+        std::error_code ec;
+        m::acp_to_u8string("hello"sv, out, ec);
+        EXPECT_FALSE(ec);
+        EXPECT_EQ(out, u8"hello"s);
+    }
+    {
+        std::error_code ec;
+        auto            r = m::acp_to_u8string("hello"sv, ec);
+        EXPECT_FALSE(ec);
+        EXPECT_EQ(r, u8"hello"s);
+    }
+}
+
+TEST(AcpAPIs_Extended, acp_to_u16string_ec)
+{
+    {
+        std::u16string  out;
+        std::error_code ec;
+        m::acp_to_u16string("hello"sv, out, ec);
+        EXPECT_FALSE(ec);
+        EXPECT_EQ(out, u"hello"s);
+    }
+    {
+        std::error_code ec;
+        auto            r = m::acp_to_u16string("hello"sv, ec);
+        EXPECT_FALSE(ec);
+        EXPECT_EQ(r, u"hello"s);
+    }
+}
+
+TEST(AcpAPIs_Extended, acp_to_u32string_ec)
+{
+    {
+        std::u32string  out;
+        std::error_code ec;
+        m::acp_to_u32string("hello"sv, out, ec);
+        EXPECT_FALSE(ec);
+        EXPECT_EQ(out, U"hello"s);
+    }
+    {
+        std::error_code ec;
+        auto            r = m::acp_to_u32string("hello"sv, ec);
+        EXPECT_FALSE(ec);
+        EXPECT_EQ(r, U"hello"s);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Optional overloads from <m/cp_acp/to_string.h>
+// ---------------------------------------------------------------------------
+
+// Nullopt propagation — void overloads
+
+TEST(AcpAPIs_Extended, optional_nullopt_void_out)
+{
+    std::optional<std::string> in  = std::nullopt;
+    std::optional<std::string> out = "sentinel"s;
+    m::acp_to_string(in, out);
+    EXPECT_FALSE(out.has_value());
+}
+
+TEST(AcpAPIs_Extended, optional_nullopt_void_out_ec)
+{
+    std::optional<std::string> in  = std::nullopt;
+    std::optional<std::string> out = "sentinel"s;
+    std::error_code            ec;
+    m::acp_to_string(in, out, ec);
+    EXPECT_FALSE(out.has_value());
+    EXPECT_FALSE(ec);
+}
+
+// Nullopt propagation — value-return overloads
+
+TEST(AcpAPIs_Extended, optional_nullopt_value_return)
+{
+    std::optional<std::string> in = std::nullopt;
+    auto                       r  = m::acp_to_string(in);
+    EXPECT_FALSE(r.has_value());
+}
+
+TEST(AcpAPIs_Extended, optional_nullopt_value_return_ec)
+{
+    std::optional<std::string> in = std::nullopt;
+    std::error_code            ec;
+    auto                       r = m::acp_to_string(in, ec);
+    EXPECT_FALSE(r.has_value());
+    EXPECT_FALSE(ec);
+}
+
+// Value present — void overloads
+
+TEST(AcpAPIs_Extended, optional_value_void_out)
+{
+    std::optional<std::string> in  = "hello"s;
+    std::optional<std::string> out = std::nullopt;
+    m::acp_to_string(in, out);
+    ASSERT_TRUE(out.has_value());
+    EXPECT_EQ(*out, "hello"s);
+}
+
+TEST(AcpAPIs_Extended, optional_value_void_out_ec)
+{
+    std::optional<std::string> in  = "world"s;
+    std::optional<std::string> out = std::nullopt;
+    std::error_code            ec;
+    m::acp_to_string(in, out, ec);
+    ASSERT_TRUE(out.has_value());
+    EXPECT_EQ(*out, "world"s);
+    EXPECT_FALSE(ec);
+}
+
+// Value present — value-return overloads
+
+TEST(AcpAPIs_Extended, optional_value_value_return)
+{
+    std::optional<std::string> in = "test"s;
+    auto                       r  = m::acp_to_string(in);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, "test"s);
+}
+
+TEST(AcpAPIs_Extended, optional_value_value_return_ec)
+{
+    std::optional<std::string> in = "test"s;
+    std::error_code            ec;
+    auto                       r = m::acp_to_string(in, ec);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, "test"s);
+    EXPECT_FALSE(ec);
+}
+
+// string_view as the optional's contained type
+
+TEST(AcpAPIs_Extended, optional_string_view_value_return)
+{
+    std::optional<std::string_view> in = "viewdata"sv;
+    auto                            r  = m::acp_to_string(in);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, "viewdata"s);
+}
+
+TEST(AcpAPIs_Extended, optional_string_view_nullopt_value_return)
+{
+    std::optional<std::string_view> in = std::nullopt;
+    auto                            r  = m::acp_to_string(in);
+    EXPECT_FALSE(r.has_value());
+}

--- a/src/Windows/libraries/multi_byte/src/multi_byte_to_utf16.cpp
+++ b/src/Windows/libraries/multi_byte/src/multi_byte_to_utf16.cpp
@@ -39,6 +39,7 @@ namespace
         if (i < 1)
         {
             ec = m::get_last_win32_error();
+            span = span.subspan(0, 0);
             return;
         }
 

--- a/src/Windows/libraries/multi_byte/src/to_span.cpp
+++ b/src/Windows/libraries/multi_byte/src/to_span.cpp
@@ -30,6 +30,13 @@ namespace m
 
     template <>
     void
+    view_to_span(multi_byte::code_page cp, std::wstring_view in, std::span<char>& out, std::error_code& ec)
+    {
+        utf16_to_multi_byte(cp, in, out, ec);
+    }
+
+    template <>
+    void
     view_to_span(multi_byte::code_page cp, std::string_view in, std::span<wchar_t>& out)
     {
         multi_byte_to_utf16(cp, in, out);

--- a/src/Windows/libraries/multi_byte/src/utf16_to_multi_byte.cpp
+++ b/src/Windows/libraries/multi_byte/src/utf16_to_multi_byte.cpp
@@ -45,6 +45,7 @@ namespace m::multi_byte::impl
         if (i < 1)
         {
             ec = get_last_win32_error();
+            buffer = buffer.subspan(0, 0);
             return;
         }
 
@@ -82,22 +83,6 @@ namespace m::multi_byte::impl
         buffer = buffer.subspan(0, i);
     }
 
-    template <typename TCharIn>
-        requires utf16_character<TCharIn>
-    [[nodiscard]]
-    std::string
-    utf16_view_to_multi_byte_fn(code_page cp, std::basic_string_view<TCharIn> view)
-    {
-        std::string result;
-
-        auto length = m::utf16_to_multi_byte_length(cp, view);
-        result.resize_and_overwrite(length, [&](auto buffer, auto size) -> auto {
-            auto span = make_span(buffer, size);
-            multi_byte::impl::utf16_to_multi_byte_fn(cp, view, span);
-            return span.size();
-        });
-        return result;
-    }
 } // namespace m::multi_byte::impl
 
 namespace m
@@ -195,32 +180,5 @@ namespace m
             return span.size();
         });
     }
-
-#if 0
-    std::size_t
-    utf16_to_multi_byte(multi_byte::code_page cp, std::u16string_view view, std::string& str)
-    {
-        std::string t;
-        auto        length = utf16_to_multi_byte_length(cp, view);
-        t.resize_and_overwrite(length, [&](auto buffer, auto buffer_size) -> auto {
-            auto span = m::make_span(buffer, buffer_size);
-            utf16_to_multi_byte(cp, view, span);
-            return span.size();
-        });
-        using std::swap;
-        swap(t, str);
-        return str.size();
-    }
-
-    template <>
-    void
-    utf16_to_multi_byte(multi_byte::code_page cp,
-                        std::wstring_view     in,
-                        std::span<char>&      out,
-                        std::error_code&      ec)
-    {
-        multi_byte::impl::utf16_to_multi_byte_fn(cp, in, out, ec);
-    }
-#endif
 
 } // namespace m

--- a/src/Windows/libraries/multi_byte/test/CMakeLists.txt
+++ b/src/Windows/libraries/multi_byte/test/CMakeLists.txt
@@ -5,6 +5,7 @@ include(GoogleTest)
 set(TEST_EXE_NAME test_multi_byte)
 
 add_executable(${TEST_EXE_NAME}
+    test_multi_byte_extended.cpp
     test_multi_byte_to_utf16.cpp
     test_utf16_to_multi_byte.cpp
     wchar_decoder.cpp

--- a/src/Windows/libraries/multi_byte/test/test_multi_byte_extended.cpp
+++ b/src/Windows/libraries/multi_byte/test/test_multi_byte_extended.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//
+// Extended tests for multi_byte conversion bugs:
+//
+//  Bug 1 — multi_byte_to_utf16 span overload with ec: on failure the output span was not
+//           zeroed, leaving callers (resize_and_overwrite based) with garbage string content.
+//
+//  Bug 2 — utf16_to_multi_byte span overload with ec: same problem on the reverse path.
+//
+//  Bug 3 — view_to_span(cp, wstring_view, span<char>&, ec) was never defined despite being
+//           declared in the header.  Every call to view_to_span with a u16string_view + ec
+//           cascaded through it, causing an unresolved external symbol.
+//
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <string_view>
+#include <system_error>
+
+#include <m/multi_byte/convert.h>
+#include <m/utility/make_span.h>
+
+#include <Windows.h>
+
+#include "multi_byte_test_data.h"
+
+using namespace std::string_view_literals;
+
+// CP-950 (Big5) is the code page exercised throughout this test suite.
+constexpr m::multi_byte::code_page dbcs_cp = m::multi_byte::code_page{950};
+
+// An invalid CP-950 byte sequence: the high byte 0x81 requires a valid DBCS
+// trail byte, but 0x20 (space) is not a legal trail byte.
+std::array<char const, 3> const bad_mbcs_bytes{'x', '\x81', '\x20'};
+auto const bad_mbcs_sv = std::string_view(bad_mbcs_bytes.data(), bad_mbcs_bytes.size());
+
+// Helper: return true if the code page is installed so tests can be skipped gracefully.
+static bool cp_is_available(m::multi_byte::code_page cp)
+{
+    return ::IsValidCodePage(m::to_underlying(cp)) != 0;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Bug 1 regression: multi_byte_to_utf16 span+ec path
+//
+// Before the fix, a MultiByteToWideChar failure left the output span at its
+// original (pre-allocated) size instead of 0.  The caller's resize_and_overwrite
+// lambda then returned that non-zero size, populating the string with garbage.
+// After the fix the span is zeroed so the lambda returns 0 and the string is empty.
+// ──────────────────────────────────────────────────────────────────────────────
+TEST(MultiByteExtended, MultiByteToUtf16SpanEcFailureLeavesSpanEmpty)
+{
+    if (!cp_is_available(dbcs_cp))
+        GTEST_SKIP() << "Code page 950 not available on this machine";
+
+    // Allocate a span large enough that garbage would be visible if not zeroed.
+    std::array<wchar_t, 32> buf{};
+    auto span = std::span<wchar_t>(buf.data(), buf.size());
+
+    std::error_code ec;
+    m::multi_byte_to_utf16(dbcs_cp, bad_mbcs_sv, span, ec);
+
+    EXPECT_TRUE(ec) << "Expected an error for invalid DBCS sequence";
+    EXPECT_EQ(span.size(), 0u) << "Output span must be empty on failure (Bug 1)";
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Bug 2 regression: utf16_to_multi_byte span+ec path
+//
+// A too-small output buffer causes WideCharToMultiByte to fail with
+// ERROR_INSUFFICIENT_BUFFER.  Before the fix the span retained its original size;
+// after the fix it is zeroed.
+//
+// mb_cp950_t2 encodes 4 wide characters each requiring 2 CP-950 bytes → 8 bytes
+// total.  Providing only a 4-byte buffer is guaranteed to be insufficient.
+// ──────────────────────────────────────────────────────────────────────────────
+TEST(MultiByteExtended, Utf16ToMultiByteSpanEcFailureLeavesSpanEmpty)
+{
+    if (!cp_is_available(dbcs_cp))
+        GTEST_SKIP() << "Code page 950 not available on this machine";
+
+    // mb_cp950_t2.m_wview is L"\ufe6b\u33d5\u5159\u2588" — 4 wchars, 8 CP-950 bytes.
+    // A 4-char buffer is smaller than the 8 bytes required, so the conversion must fail.
+    std::array<char, 4> buf{};
+    auto span = std::span<char>(buf.data(), buf.size());
+
+    std::error_code ec;
+    m::utf16_to_multi_byte(dbcs_cp, mb_cp950_t2.m_wview, span, ec);
+
+    EXPECT_TRUE(ec) << "Expected an error for too-small output buffer";
+    EXPECT_EQ(span.size(), 0u) << "Output span must be empty on failure (Bug 2)";
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Bug 3 regression: view_to_span(cp, wstring_view, span<char>&, ec) must exist.
+//
+// Happy-path test confirms the specialization is reachable and produces correct
+// output.  mb_cp950_t1 is L"\ufe6b" (1 wide char) → {0xa2, 0x4e} in CP-950.
+// ──────────────────────────────────────────────────────────────────────────────
+TEST(MultiByteExtended, ViewToSpanWstringViewEcHappyPath)
+{
+    if (!cp_is_available(dbcs_cp))
+        GTEST_SKIP() << "Code page 950 not available on this machine";
+
+    std::array<char, 8> buf{};
+    auto span = std::span<char>(buf.data(), buf.size());
+
+    std::error_code ec;
+    m::view_to_span(dbcs_cp, mb_cp950_t1.m_wview, span, ec);
+
+    EXPECT_FALSE(ec) << "Unexpected error: " << ec.message();
+    EXPECT_EQ(span.size(), mb_cp950_t1.m_view.size());
+    EXPECT_EQ(std::string_view(span.data(), span.size()), mb_cp950_t1.m_view);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// view_to_span with u16string_view + ec: exercises the u16string_view specialization
+// which delegates to the (previously missing) wstring_view+ec specialization.
+// ──────────────────────────────────────────────────────────────────────────────
+TEST(MultiByteExtended, ViewToSpanU16StringViewEcHappyPath)
+{
+    if (!cp_is_available(dbcs_cp))
+        GTEST_SKIP() << "Code page 950 not available on this machine";
+
+    std::array<char, 8> buf{};
+    auto span = std::span<char>(buf.data(), buf.size());
+
+    std::error_code ec;
+    m::view_to_span(dbcs_cp, mb_cp950_t1.m_u16view, span, ec);
+
+    EXPECT_FALSE(ec) << "Unexpected error: " << ec.message();
+    EXPECT_EQ(span.size(), mb_cp950_t1.m_view.size());
+    EXPECT_EQ(std::string_view(span.data(), span.size()), mb_cp950_t1.m_view);
+}

--- a/src/Windows/libraries/win32/include/m/win32/event.h
+++ b/src/Windows/libraries/win32/include/m/win32/event.h
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 
@@ -120,7 +121,5 @@ namespace m::win32
     private:
         event_kind m_event_kind{event_kind::none};
     };
-
-    M_DEFINE_SCOPED_ENUM_BITFLAG_OPS(event::event_kind);
 
 } // namespace m::win32

--- a/src/Windows/libraries/win32/include/m/win32/filetime_clock.h
+++ b/src/Windows/libraries/win32/include/m/win32/filetime_clock.h
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 

--- a/src/Windows/libraries/win32/include/m/win32/handle.h
+++ b/src/Windows/libraries/win32/include/m/win32/handle.h
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 

--- a/src/Windows/libraries/win32/include/m/win32/registry.h
+++ b/src/Windows/libraries/win32/include/m/win32/registry.h
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 

--- a/src/Windows/libraries/win32/include/m/win32/threadpool.h
+++ b/src/Windows/libraries/win32/include/m/win32/threadpool.h
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 
@@ -126,14 +127,14 @@ namespace m::win32::threadpool
         void
         set_wait_until(HANDLE h, std::chrono::time_point<Clock, Duration> const& tp)
         {
-            do_set_wait_unil(h, std::chrono::time_point_cast<utc_time_point_type>(tp));
+            do_set_wait_until(h, std::chrono::time_point_cast<utc_time_point_type>(tp));
         }
 
         template <typename Clock, typename Duration>
         void
         set_wait_until(event const& e, std::chrono::time_point<Clock, Duration> const& tp)
         {
-            do_set_wait_unil(e.get(), tp);
+            do_set_wait_until(e.get(), std::chrono::time_point_cast<utc_time_point_type>(tp));
         }
 
     private:

--- a/src/Windows/libraries/win32/src/event.cpp
+++ b/src/Windows/libraries/win32/src/event.cpp
@@ -58,7 +58,10 @@ namespace m::win32
             return m::make_win32_error_code(last_error);
         }
 
-        event e{evt};
+        event e{evt,
+                (flags & create_event_flags::manual_reset) != create_event_flags{}
+                    ? event_kind::manual
+                    : event_kind::automatic};
         using std::swap;
         swap(e, *this);
 

--- a/src/Windows/libraries/win32/src/filetime_clock.cpp
+++ b/src/Windows/libraries/win32/src/filetime_clock.cpp
@@ -12,10 +12,8 @@ namespace m::win32
     filetime_clock::time_point
     filetime_clock::now()
     {
-        SYSTEMTIME st{};
-        FILETIME   ft{};
-        GetSystemTime(&st);
-        SystemTimeToFileTime(&st, &ft);
+        FILETIME ft{};
+        ::GetSystemTimeAsFileTime(&ft);
 
         LARGE_INTEGER li{};
         li.LowPart  = ft.dwLowDateTime;
@@ -54,10 +52,10 @@ namespace m::win32
     filetime_clock::to_sys(duration const& dur)
     {
         LARGE_INTEGER li{};
-        li.QuadPart = dur.count();
+        li.QuadPart = -dur.count();
         FILETIME ft{};
         ft.dwLowDateTime  = li.LowPart;
-        ft.dwHighDateTime = static_cast<decltype(ft.dwHighDateTime)>(-li.HighPart);
+        ft.dwHighDateTime = static_cast<decltype(ft.dwHighDateTime)>(li.HighPart);
         return ft;
     }
 

--- a/src/Windows/libraries/win32/test/test_registry_helpers.cpp
+++ b/src/Windows/libraries/win32/test/test_registry_helpers.cpp
@@ -3,15 +3,12 @@
 
 #include <gtest/gtest.h>
 
-#include <format>
-#include <string>
 #include <string_view>
 
 #include <Windows.h>
 
 #include <m/win32/registry.h>
 
-using namespace std::string_literals;
 using namespace std::string_view_literals;
 
 TEST(Win32RegistryHelpers, PositivePredefinedKeyLookup)

--- a/src/Windows/libraries/win32/test/test_registry_helpers.cpp
+++ b/src/Windows/libraries/win32/test/test_registry_helpers.cpp
@@ -130,6 +130,105 @@ TEST(Win32RegistryHelpers, TestClosingHKCU)
     hkey hkcu{HKEY_CURRENT_USER};
 }
 
+TEST(Win32RegistryHelpers, HkeyDefaultIsInvalid)
+{
+    m::win32::registry::hkey k;
+    EXPECT_FALSE(k.is_valid());
+    EXPECT_FALSE(static_cast<bool>(k));
+}
+
+TEST(Win32RegistryHelpers, HkeyPredefinedGet)
+{
+    // Wrapping a predefined HKEY stores the value and returns it via get().
+    // is_valid() intentionally returns false for predefined keys because they
+    // are not closable via RegCloseKey.
+    m::win32::registry::hkey k{HKEY_CURRENT_USER};
+    EXPECT_EQ(k.get(), HKEY_CURRENT_USER);
+    // Destructor must not call RegCloseKey on predefined keys — just verify
+    // construction + destruction does not crash.
+}
+
+TEST(Win32RegistryHelpers, HkeySwap)
+{
+    using namespace m::win32::registry;
+
+    // Open a real key so is_valid() reflects a closable hkey.
+    hkey a;
+    ASSERT_FALSE(a.openq(predefined_key::current_user, L"Software", KEY_QUERY_VALUE));
+    hkey b;
+
+    EXPECT_TRUE(a.is_valid());
+    EXPECT_FALSE(b.is_valid());
+
+    a.swap(b);
+
+    EXPECT_FALSE(a.is_valid());
+    EXPECT_TRUE(b.is_valid());
+}
+
+TEST(Win32RegistryHelpers, OpenqHappyPath)
+{
+    // HKCU\Software exists on essentially all Windows machines.
+    using namespace m::win32::registry;
+
+    hkey k;
+    auto ec = k.openq(predefined_key::current_user, L"Software", KEY_QUERY_VALUE);
+
+    EXPECT_FALSE(ec) << ec.message();
+    EXPECT_TRUE(k.is_valid());
+}
+
+TEST(Win32RegistryHelpers, OpenqFailurePath)
+{
+    using namespace m::win32::registry;
+
+    hkey k;
+    auto ec = k.openq(predefined_key::current_user,
+                      L"Software\\__nonexistent_key_m_win32_test__",
+                      KEY_QUERY_VALUE);
+
+    EXPECT_TRUE(ec) << "Expected error for non-existent key";
+    // hkey must remain invalid after a failed openq.
+    EXPECT_FALSE(k.is_valid());
+}
+
+TEST(Win32RegistryHelpers, OpenThrowsOnSuccess)
+{
+    using namespace m::win32::registry;
+
+    hkey k;
+    ASSERT_NO_THROW(k.open(predefined_key::current_user, L"Software", KEY_QUERY_VALUE));
+    EXPECT_TRUE(k.is_valid());
+}
+
+TEST(Win32RegistryHelpers, OpenThrowsOnFailure)
+{
+    using namespace m::win32::registry;
+
+    hkey k;
+    EXPECT_ANY_THROW(k.open(predefined_key::current_user,
+                            L"Software\\__nonexistent_key_m_win32_test__",
+                            KEY_QUERY_VALUE));
+    EXPECT_FALSE(k.is_valid());
+}
+
+TEST(Win32RegistryHelpers, OpenqFromHkeyBase)
+{
+    // Open HKCU\Software, then open a subkey from the resulting hkey.
+    using namespace m::win32::registry;
+
+    hkey software;
+    auto ec = software.openq(predefined_key::current_user, L"Software", KEY_QUERY_VALUE);
+    ASSERT_FALSE(ec) << ec.message();
+    ASSERT_TRUE(software.is_valid());
+
+    // Now open using the hkey_base overload (openq(hkey const&, ...)).
+    hkey software2;
+    ec = software2.openq(software, L"", KEY_QUERY_VALUE);
+    EXPECT_FALSE(ec) << ec.message();
+    EXPECT_TRUE(software2.is_valid());
+}
+
 TEST(Win32RegistryHelpers, TestResetKey)
 {
     using namespace m::win32::registry;

--- a/src/Windows/libraries/win32/test/test_win32_event.cpp
+++ b/src/Windows/libraries/win32/test/test_win32_event.cpp
@@ -27,6 +27,98 @@ TEST(Win32Event, CreateqSetsEventKindAutomatic)
     EXPECT_EQ(e.get_event_kind(), m::win32::event::event_kind::automatic);
 }
 
+TEST(Win32Event, IsValid)
+{
+    m::win32::event e_null;
+    EXPECT_FALSE(e_null.is_valid());
+
+    m::win32::event e_valid(m::win32::create_event_flags::zero);
+    EXPECT_TRUE(e_valid.is_valid());
+
+    e_valid.reset();
+    EXPECT_FALSE(e_valid.is_valid());
+}
+
+TEST(Win32Event, MoveAssign)
+{
+    auto e1 = m::win32::event(m::win32::create_event_flags::manual_reset);
+    auto e2 = m::win32::event();
+
+    EXPECT_TRUE(e1.is_valid());
+    EXPECT_FALSE(e2.is_valid());
+    EXPECT_EQ(e1.get_event_kind(), m::win32::event::event_kind::manual);
+
+    e2 = std::move(e1);
+
+    EXPECT_FALSE(e1.is_valid());
+    EXPECT_EQ(e1.get_event_kind(), m::win32::event::event_kind::none);
+    EXPECT_TRUE(e2.is_valid());
+    EXPECT_EQ(e2.get_event_kind(), m::win32::event::event_kind::manual);
+}
+
+TEST(Win32Event, CombinedFlagsInitialSetManualReset)
+{
+    // Create an initially-set manual-reset event.
+    auto flags = m::win32::create_event_flags::initial_set | m::win32::create_event_flags::manual_reset;
+    auto e     = m::win32::event(flags);
+
+    EXPECT_TRUE(e.is_valid());
+    EXPECT_EQ(e.get_event_kind(), m::win32::event::event_kind::manual);
+
+    // Because it was created initially signalled, WaitForSingleObject should return
+    // immediately without blocking.
+    auto const result = ::WaitForSingleObject(e.get(), 0);
+    EXPECT_EQ(result, WAIT_OBJECT_0);
+}
+
+TEST(Win32Event, SetEventStateSetThenReset)
+{
+    // Manually-reset event starts unsignalled.
+    auto e = m::win32::event(m::win32::create_event_flags::manual_reset);
+
+    // Should not be signalled yet.
+    EXPECT_EQ(::WaitForSingleObject(e.get(), 0), WAIT_TIMEOUT);
+
+    e.set_event_state(m::win32::event::event_state::set);
+    EXPECT_EQ(::WaitForSingleObject(e.get(), 0), WAIT_OBJECT_0);
+
+    e.set_event_state(m::win32::event::event_state::reset);
+    EXPECT_EQ(::WaitForSingleObject(e.get(), 0), WAIT_TIMEOUT);
+}
+
+TEST(Win32Event, AutoResetEventClearsAfterWait)
+{
+    // Auto-reset event created initially signalled.
+    auto flags = m::win32::create_event_flags::initial_set; // no manual_reset bit
+    auto e     = m::win32::event(flags);
+    EXPECT_EQ(e.get_event_kind(), m::win32::event::event_kind::automatic);
+
+    // First wait succeeds and atomically resets the event.
+    EXPECT_EQ(::WaitForSingleObject(e.get(), 0), WAIT_OBJECT_0);
+
+    // Second wait times out — event was auto-cleared.
+    EXPECT_EQ(::WaitForSingleObject(e.get(), 0), WAIT_TIMEOUT);
+}
+
+TEST(Win32Event, SignalAndWaitAcrossThreads)
+{
+    auto e = m::win32::event(m::win32::create_event_flags::manual_reset);
+
+    // Signal from a threadpool callback, then wait on the main thread.
+    auto callback = [](PTP_CALLBACK_INSTANCE, PVOID pv, PTP_WORK) noexcept {
+        ::SetEvent(static_cast<HANDLE>(*static_cast<m::win32::event*>(pv)));
+    };
+
+    PTP_WORK work = ::CreateThreadpoolWork(callback, &e, nullptr);
+    ASSERT_NE(work, PTP_WORK{});
+
+    ::SubmitThreadpoolWork(work);
+    ::WaitForThreadpoolWorkCallbacks(work, FALSE);
+    ::CloseThreadpoolWork(work);
+
+    EXPECT_EQ(::WaitForSingleObject(e.get(), 0), WAIT_OBJECT_0);
+}
+
 TEST(Win32Event, ConstructNull)
 {
     auto e1 = m::win32::event();

--- a/src/Windows/libraries/win32/test/test_win32_event.cpp
+++ b/src/Windows/libraries/win32/test/test_win32_event.cpp
@@ -3,16 +3,29 @@
 
 #include <gtest/gtest.h>
 
-#include <format>
-#include <string>
-#include <string_view>
-
 #include <Windows.h>
 
 #include <m/win32/event.h>
 
-using namespace std::string_literals;
-using namespace std::string_view_literals;
+TEST(Win32Event, CreateqSetsEventKindManual)
+{
+    m::win32::event e;
+    auto const      ec = e.createq(m::win32::create_event_flags::manual_reset);
+
+    EXPECT_FALSE(ec) << ec.message();
+    EXPECT_NE(e.get(), nullptr);
+    EXPECT_EQ(e.get_event_kind(), m::win32::event::event_kind::manual);
+}
+
+TEST(Win32Event, CreateqSetsEventKindAutomatic)
+{
+    m::win32::event e;
+    auto const      ec = e.createq(m::win32::create_event_flags::zero);
+
+    EXPECT_FALSE(ec) << ec.message();
+    EXPECT_NE(e.get(), nullptr);
+    EXPECT_EQ(e.get_event_kind(), m::win32::event::event_kind::automatic);
+}
 
 TEST(Win32Event, ConstructNull)
 {

--- a/src/Windows/libraries/win32/test/test_win32_threadpool.cpp
+++ b/src/Windows/libraries/win32/test/test_win32_threadpool.cpp
@@ -4,9 +4,11 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
 
 #include <Windows.h>
 
+#include <m/win32/event.h>
 #include <m/win32/threadpool.h>
 
 TEST(Win32Threadpool, TpWorkSubmitAndWait)
@@ -27,7 +29,7 @@ TEST(Win32Threadpool, TpWorkSubmitAndWait)
 
 TEST(Win32Threadpool, TpWorkSubmitMultiple)
 {
-    constexpr int N = 10;
+    constexpr int    N = 10;
     std::atomic<int> counter{0};
 
     auto callback = [](PTP_CALLBACK_INSTANCE, PVOID pv, PTP_WORK) noexcept {
@@ -60,4 +62,123 @@ TEST(Win32Threadpool, TpWorkMoveConstruct)
     b.submit();
     b.wait_for_callbacks(false);
     EXPECT_EQ(counter.load(), 1);
+}
+
+TEST(Win32Threadpool, TpWorkMoveAssign)
+{
+    std::atomic<int> counter{0};
+
+    auto callback = [](PTP_CALLBACK_INSTANCE, PVOID pv, PTP_WORK) noexcept {
+        static_cast<std::atomic<int>*>(pv)->fetch_add(1, std::memory_order_relaxed);
+    };
+
+    m::win32::threadpool::tp_work a(callback, &counter);
+    m::win32::threadpool::tp_work b;
+
+    EXPECT_FALSE(static_cast<bool>(b));
+    b = std::move(a);
+    EXPECT_FALSE(static_cast<bool>(a));
+    EXPECT_TRUE(static_cast<bool>(b));
+
+    b.submit();
+    b.wait_for_callbacks(false);
+    EXPECT_EQ(counter.load(), 1);
+}
+
+TEST(Win32Threadpool, TpWorkReset)
+{
+    std::atomic<int> counter{0};
+
+    auto callback = [](PTP_CALLBACK_INSTANCE, PVOID pv, PTP_WORK) noexcept {
+        static_cast<std::atomic<int>*>(pv)->fetch_add(1, std::memory_order_relaxed);
+    };
+
+    m::win32::threadpool::tp_work work(callback, &counter);
+    EXPECT_TRUE(static_cast<bool>(work));
+
+    work.reset();
+    EXPECT_FALSE(static_cast<bool>(work));
+}
+
+TEST(Win32Threadpool, TpTimerConstructAndIsSet)
+{
+    auto callback = [](PTP_CALLBACK_INSTANCE, PVOID, PTP_TIMER) noexcept {};
+
+    m::win32::threadpool::tp_timer timer(callback);
+    EXPECT_TRUE(static_cast<bool>(timer));
+
+    // Timer was never armed, so is_set() should be false.
+    EXPECT_FALSE(timer.is_set());
+}
+
+TEST(Win32Threadpool, TpTimerSetAndCancel)
+{
+    std::atomic<bool> fired{false};
+
+    auto callback = [](PTP_CALLBACK_INSTANCE, PVOID pv, PTP_TIMER) noexcept {
+        static_cast<std::atomic<bool>*>(pv)->store(true, std::memory_order_relaxed);
+    };
+
+    m::win32::threadpool::tp_timer timer(callback, &fired);
+    EXPECT_FALSE(timer.is_set());
+
+    // Arm the timer 60 seconds in the future (absolute UTC FILETIME) so that
+    // cancel() wins the race without any timing sensitivity.
+    FILETIME due{};
+    ::GetSystemTimeAsFileTime(&due);
+    ULONGLONG ticks = (static_cast<ULONGLONG>(due.dwHighDateTime) << 32) | due.dwLowDateTime;
+    ticks += 600'000'000ULL; // 60 s in 100-ns units
+    due.dwLowDateTime  = static_cast<DWORD>(ticks & 0xFFFF'FFFFUL);
+    due.dwHighDateTime = static_cast<DWORD>(ticks >> 32);
+
+    timer.set(due);
+    EXPECT_TRUE(timer.is_set());
+
+    timer.cancel();
+    EXPECT_FALSE(timer.is_set());
+}
+
+TEST(Win32Threadpool, TpTimerFiresAndWait)
+{
+    // Use a manual-reset event for deterministic synchronization: the callback
+    // signals it, the main thread waits on it with a generous timeout.
+    auto done = m::win32::event(m::win32::create_event_flags::manual_reset);
+
+    auto callback = [](PTP_CALLBACK_INSTANCE, PVOID pv, PTP_TIMER) noexcept {
+        ::SetEvent(static_cast<HANDLE>(*static_cast<m::win32::event*>(pv)));
+    };
+
+    m::win32::threadpool::tp_timer timer(callback, &done);
+
+    // A zero FILETIME is January 1, 1601 — strictly in the past — so the
+    // timer fires immediately.
+    FILETIME due{};
+    timer.set(due);
+
+    EXPECT_EQ(::WaitForSingleObject(done.get(), 5000), WAIT_OBJECT_0);
+}
+
+TEST(Win32Threadpool, TpWaitConstructAndSetWait)
+{
+    // "trigger" is the event the waiter watches. "done" is signalled by the
+    // callback so the main thread can wait deterministically.
+    auto trigger = m::win32::event(
+        m::win32::create_event_flags::initial_set | m::win32::create_event_flags::manual_reset);
+    auto done = m::win32::event(m::win32::create_event_flags::manual_reset);
+
+    struct ctx_t
+    {
+        m::win32::event* done;
+    } ctx{&done};
+
+    auto callback = [](PTP_CALLBACK_INSTANCE, PVOID pv, PTP_WAIT, TP_WAIT_RESULT) noexcept {
+        auto* c = static_cast<ctx_t*>(pv);
+        ::SetEvent(static_cast<HANDLE>(*c->done));
+    };
+
+    m::win32::threadpool::tp_wait waiter(callback, &ctx);
+    // trigger is already signalled, so the callback fires immediately.
+    waiter.set_wait(trigger);
+
+    EXPECT_EQ(::WaitForSingleObject(done.get(), 5000), WAIT_OBJECT_0);
 }

--- a/src/Windows/libraries/win32/test/test_win32_threadpool.cpp
+++ b/src/Windows/libraries/win32/test/test_win32_threadpool.cpp
@@ -3,15 +3,61 @@
 
 #include <gtest/gtest.h>
 
-#include <format>
-#include <string>
-#include <string_view>
+#include <atomic>
 
 #include <Windows.h>
 
 #include <m/win32/threadpool.h>
 
-using namespace std::string_literals;
-using namespace std::string_view_literals;
+TEST(Win32Threadpool, TpWorkSubmitAndWait)
+{
+    std::atomic<int> counter{0};
 
-TEST(Win32Threadpool, First) { EXPECT_EQ(static_cast<DWORD>(100), 100); }
+    auto callback = [](PTP_CALLBACK_INSTANCE, PVOID pv, PTP_WORK) noexcept {
+        auto* p = static_cast<std::atomic<int>*>(pv);
+        p->fetch_add(1, std::memory_order_relaxed);
+    };
+
+    m::win32::threadpool::tp_work work(callback, &counter);
+    work.submit();
+    work.wait_for_callbacks(false);
+
+    EXPECT_EQ(counter.load(), 1);
+}
+
+TEST(Win32Threadpool, TpWorkSubmitMultiple)
+{
+    constexpr int N = 10;
+    std::atomic<int> counter{0};
+
+    auto callback = [](PTP_CALLBACK_INSTANCE, PVOID pv, PTP_WORK) noexcept {
+        auto* p = static_cast<std::atomic<int>*>(pv);
+        p->fetch_add(1, std::memory_order_relaxed);
+    };
+
+    m::win32::threadpool::tp_work work(callback, &counter);
+    for (int i = 0; i < N; ++i)
+        work.submit();
+    work.wait_for_callbacks(false);
+
+    EXPECT_EQ(counter.load(), N);
+}
+
+TEST(Win32Threadpool, TpWorkMoveConstruct)
+{
+    std::atomic<int> counter{0};
+
+    auto callback = [](PTP_CALLBACK_INSTANCE, PVOID pv, PTP_WORK) noexcept {
+        static_cast<std::atomic<int>*>(pv)->fetch_add(1, std::memory_order_relaxed);
+    };
+
+    m::win32::threadpool::tp_work a(callback, &counter);
+    m::win32::threadpool::tp_work b(std::move(a));
+
+    EXPECT_FALSE(static_cast<bool>(a));
+    EXPECT_TRUE(static_cast<bool>(b));
+
+    b.submit();
+    b.wait_for_callbacks(false);
+    EXPECT_EQ(counter.load(), 1);
+}

--- a/src/Windows/libraries/windows_wrappers/include/m/windows_wrappers/win32_dword_ms.h
+++ b/src/Windows/libraries/windows_wrappers/include/m/windows_wrappers/win32_dword_ms.h
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 

--- a/src/Windows/libraries/windows_wrappers/test/test_win32_dword_ms.cpp
+++ b/src/Windows/libraries/windows_wrappers/test/test_win32_dword_ms.cpp
@@ -3,21 +3,80 @@
 
 #include <gtest/gtest.h>
 
-#include <format>
-#include <string>
-#include <string_view>
-
 #include <Windows.h>
 
 #include <m/windows_wrappers/win32_dword_ms.h>
 
-using namespace std::string_literals;
-using namespace std::string_view_literals;
-
-TEST(Win32DWORDMs, First)
+TEST(Win32DWORDMs, ValueInit)
 {
-    DWORD             ms = 100;
-    m::win32_dword_ms x(ms);
+    // Value-initialization must zero-initialize the underlying DWORD.
+    m::win32_dword_ms x{};
+    EXPECT_EQ(static_cast<DWORD>(x), DWORD{0});
+}
 
-    EXPECT_EQ(static_cast<DWORD>(x), 100);
+TEST(Win32DWORDMs, ExplicitConstruct)
+{
+    m::win32_dword_ms x(DWORD{100});
+    EXPECT_EQ(static_cast<DWORD>(x), DWORD{100});
+}
+
+TEST(Win32DWORDMs, EqualityTrue)
+{
+    m::win32_dword_ms a(DWORD{42});
+    m::win32_dword_ms b(DWORD{42});
+    EXPECT_EQ(a, b);
+}
+
+TEST(Win32DWORDMs, EqualityFalse)
+{
+    m::win32_dword_ms a(DWORD{1});
+    m::win32_dword_ms b(DWORD{2});
+    EXPECT_NE(a, b);
+}
+
+TEST(Win32DWORDMs, CopyConstruct)
+{
+    m::win32_dword_ms a(DWORD{7});
+    m::win32_dword_ms b(a); // NOLINT(performance-unnecessary-copy-initialization)
+    EXPECT_EQ(a, b);
+    EXPECT_EQ(static_cast<DWORD>(b), DWORD{7});
+}
+
+TEST(Win32DWORDMs, CopyAssign)
+{
+    m::win32_dword_ms a(DWORD{7});
+    m::win32_dword_ms b(DWORD{99});
+    b = a;
+    EXPECT_EQ(static_cast<DWORD>(b), DWORD{7});
+}
+
+TEST(Win32DWORDMs, MoveConstruct)
+{
+    m::win32_dword_ms a(DWORD{55});
+    m::win32_dword_ms b(std::move(a));
+    EXPECT_EQ(static_cast<DWORD>(b), DWORD{55});
+}
+
+TEST(Win32DWORDMs, MoveAssign)
+{
+    m::win32_dword_ms a(DWORD{55});
+    m::win32_dword_ms b(DWORD{0});
+    b = std::move(a);
+    EXPECT_EQ(static_cast<DWORD>(b), DWORD{55});
+}
+
+TEST(Win32DWORDMs, Swap)
+{
+    m::win32_dword_ms a(DWORD{10});
+    m::win32_dword_ms b(DWORD{20});
+    a.swap(b);
+    EXPECT_EQ(static_cast<DWORD>(a), DWORD{20});
+    EXPECT_EQ(static_cast<DWORD>(b), DWORD{10});
+}
+
+TEST(Win32DWORDMs, ConstexprUsage)
+{
+    constexpr m::win32_dword_ms x(DWORD{5000});
+    static_assert(static_cast<DWORD>(x) == DWORD{5000});
+    EXPECT_EQ(static_cast<DWORD>(x), DWORD{5000});
 }

--- a/src/libraries/wrappers/include/m/wrappers/wrapper_template.h
+++ b/src/libraries/wrappers/include/m/wrappers/wrapper_template.h
@@ -110,12 +110,13 @@ namespace m
         using base = nonscalar_wrapper<T, UniqueT>;
 
     public:
+        using base::base;
         using base::m_v;
 
         constexpr auto
         operator<=>(scalar_wrapper other) const
         {
-            return operator<=>(m_v, other.m_v);
+            return m_v <=> other.m_v;
         }
     };
 

--- a/src/libraries/wrappers/test/test_template.cpp
+++ b/src/libraries/wrappers/test/test_template.cpp
@@ -3,11 +3,98 @@
 
 #include <gtest/gtest.h>
 
-#include <format>
-#include <string>
-#include <string_view>
+#include <compare>
 
 #include <m/wrappers/wrapper_template.h>
 
-using namespace std::string_literals;
-using namespace std::string_view_literals;
+namespace
+{
+    // Unique tag types for test instantiations
+    struct tag_nonscalar {};
+    struct tag_scalar {};
+
+    using test_nonscalar = m::nonscalar_wrapper<int, tag_nonscalar>;
+    using test_scalar    = m::scalar_wrapper<int, tag_scalar>;
+} // namespace
+
+// ── nonscalar_wrapper ────────────────────────────────────────────────────────
+
+TEST(NonScalarWrapper, ValueInit)
+{
+    test_nonscalar x{};
+    EXPECT_EQ(static_cast<int>(x), 0);
+}
+
+TEST(NonScalarWrapper, ExplicitConstruct)
+{
+    test_nonscalar x(42);
+    EXPECT_EQ(static_cast<int>(x), 42);
+}
+
+TEST(NonScalarWrapper, EqualityTrue)
+{
+    EXPECT_EQ(test_nonscalar(7), test_nonscalar(7));
+}
+
+TEST(NonScalarWrapper, EqualityFalse)
+{
+    EXPECT_NE(test_nonscalar(1), test_nonscalar(2));
+}
+
+TEST(NonScalarWrapper, CopyConstruct)
+{
+    test_nonscalar a(10);
+    test_nonscalar b(a); // NOLINT
+    EXPECT_EQ(a, b);
+}
+
+TEST(NonScalarWrapper, CopyAssign)
+{
+    test_nonscalar a(10);
+    test_nonscalar b(99);
+    b = a;
+    EXPECT_EQ(static_cast<int>(b), 10);
+}
+
+TEST(NonScalarWrapper, MoveConstruct)
+{
+    test_nonscalar a(10);
+    test_nonscalar b(std::move(a));
+    EXPECT_EQ(static_cast<int>(b), 10);
+}
+
+TEST(NonScalarWrapper, MoveAssign)
+{
+    test_nonscalar a(10);
+    test_nonscalar b(0);
+    b = std::move(a);
+    EXPECT_EQ(static_cast<int>(b), 10);
+}
+
+TEST(NonScalarWrapper, Swap)
+{
+    test_nonscalar a(1);
+    test_nonscalar b(2);
+    a.swap(b);
+    EXPECT_EQ(static_cast<int>(a), 2);
+    EXPECT_EQ(static_cast<int>(b), 1);
+}
+
+TEST(NonScalarWrapper, ConstexprUsage)
+{
+    constexpr test_nonscalar x(99);
+    static_assert(static_cast<int>(x) == 99);
+    EXPECT_EQ(static_cast<int>(x), 99);
+}
+
+// ── scalar_wrapper ───────────────────────────────────────────────────────────
+
+TEST(ScalarWrapper, ThreeWayCompare)
+{
+    test_scalar a(1);
+    test_scalar b(2);
+    EXPECT_LT(static_cast<int>(a), static_cast<int>(b));
+    EXPECT_TRUE((a <=> b) < 0);
+    EXPECT_TRUE((b <=> a) > 0);
+    EXPECT_TRUE((a <=> a) == 0);
+}


### PR DESCRIPTION
Changes to clean up how cp_acp conversions are done