### PR TITLE
ci: add tag-triggered GitHub release workflow with CPack zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,17 @@ jobs:
         shell: bash
         run: |
           tag="${{ github.ref_name }}"
-          # Strict SemVer: numeric identifiers have no leading zeroes, so each of
-          # MAJOR/MINOR/PATCH is either 0 or a non-zero-led digit run.
-          if [[ ! "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+          # This is the official semver.org recommended regex, adapted to POSIX
+          # ERE (bash [[ =~ ]]): non-capturing groups become plain groups and \d
+          # becomes [0-9]. Enforcing the full grammar means:
+          #   * MAJOR/MINOR/PATCH are numeric with no leading zeroes (0 | [1-9]...)
+          #   * each dot-separated pre-release/build identifier is non-empty and
+          #     well-formed, so junk like v1.2.3-alpha..1 or v1.2.3+build..5 (empty
+          #     identifiers) is rejected even though it "looks" close to semver.
+          #   * a pre-release numeric identifier has no leading zeroes, but build
+          #     identifiers may (per spec).
+          semver='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
+          if [[ ! "$tag" =~ $semver ]]; then
             echo "::error::Tag '$tag' is not a strict vX.Y.Z[-prerelease][+build] semver tag; refusing to release."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,9 +116,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # github.ref_name is the tag that triggered this run, e.g. v0.3.3.
-          # Mark anything with a hyphen (v0.3.3-rc1) as a pre-release.
+          # A SemVer pre-release is a '-' that comes before any '+build' metadata
+          # (e.g. v0.3.3-rc1). Build metadata may itself contain hyphens
+          # (e.g. v1.2.3+build-foo), so strip everything from the first '+'
+          # before testing for a pre-release hyphen to avoid false positives.
+          tag="${{ github.ref_name }}"
+          version_no_build="${tag%%+*}"
           PRERELEASE_FLAG=""
-          case "${{ github.ref_name }}" in
+          case "$version_no_build" in
             *-*) PRERELEASE_FLAG="--prerelease" ;;
           esac
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+# Tag-triggered release.
+#
+# How to cut a release:
+#
+#   git tag v0.3.3        # pick the next version; must start with "v"
+#   git push origin v0.3.3
+#
+# Pushing a tag that looks like vX.Y.Z starts this workflow. It builds the
+# project in Release, packages everything into a .zip with CPack, and publishes
+# a GitHub Release named after the tag with the .zip attached.
+#
+# The project's version comes from this same tag: the top-level CMakeLists.txt
+# runs `git describe --tags --match "v*"`, so the tag you push IS the version
+# that gets built. No version files to keep in sync.
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"      # e.g. v0.3.3
+      - "v[0-9]+.[0-9]+.[0-9]+-*"    # e.g. v0.3.3-rc1 (pre-releases)
+
+permissions:
+  contents: write   # needed to create the GitHub Release
+
+jobs:
+  release:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: 'recursive'
+          # Full history + tags so the CMake `git describe` version resolves to
+          # the tag that triggered this run.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set reusable strings
+        id: strings
+        shell: bash
+        run: |
+          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+          echo "dist-dir=${{ github.workspace }}/dist" >> "$GITHUB_OUTPUT"
+
+      - name: Bootstrap vcpkg
+        shell: bash
+        run: "${{ github.workspace }}/vcpkg/bootstrap-vcpkg.bat"
+
+      - name: Run vcpkg
+        shell: bash
+        run: "${{ github.workspace }}/vcpkg/vcpkg" install
+
+      - name: Configure CMake
+        run: >
+          cmake
+          -D CMAKE_BUILD_TYPE=Release
+          -D CMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+          -B ${{ steps.strings.outputs.build-output-dir }}
+          -S ${{ github.workspace }}
+
+      - name: Build
+        run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config Release --parallel
+
+      - name: Package (CPack -> .zip)
+        run: >
+          cpack
+          --config ${{ steps.strings.outputs.build-output-dir }}/CPackConfig.cmake
+          -C Release
+          -B ${{ steps.strings.outputs.dist-dir }}
+
+      - name: Publish GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # github.ref_name is the tag that triggered this run, e.g. v0.3.3.
+          # Mark anything with a hyphen (v0.3.3-rc1) as a pre-release.
+          PRERELEASE_FLAG=""
+          case "${{ github.ref_name }}" in
+            *-*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
+
+          gh release create "${{ github.ref_name }}" \
+            "${{ steps.strings.outputs.dist-dir }}"/*.zip \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            $PRERELEASE_FLAG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,11 @@ on:
   push:
     tags:
       # GitHub tag filters use glob (minimatch) syntax, not regex, so we cannot
-      # use `+` quantifiers here. "v[0-9]*" matches v followed by a digit then
-      # anything, covering both vX.Y.Z and pre-releases like vX.Y.Z-rc1.
-      - "v[0-9]*"
+      # use `+` quantifiers. Requiring the two dots enforces the vX.Y.Z shape and
+      # avoids firing on tags like v1 or v12foo. The trailing segment's `*` still
+      # allows pre-release suffixes such as v0.3.3-rc1. (This does not reject
+      # v1.2.3.4; add a runtime semver check if that strictness is needed.)
+      - "v[0-9]*.[0-9]*.[0-9]*"
 
 permissions:
   contents: write   # needed to create the GitHub Release
@@ -61,11 +63,18 @@ jobs:
           cmake
           -D CMAKE_BUILD_TYPE=Release
           -D CMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+          -D build_tests=ON
+          -D BUILD_TESTING=ON
           -B ${{ steps.strings.outputs.build-output-dir }}
           -S ${{ github.workspace }}
 
       - name: Build
         run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config Release --parallel
+
+      - name: Test
+        # Don't publish a release artifact that fails the suite the rest of CI runs.
+        working-directory: ${{ steps.strings.outputs.build-output-dir }}
+        run: ctest --build-config Release --output-on-failure
 
       - name: Package (CPack -> .zip)
         run: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,12 @@ on:
 permissions:
   contents: write   # needed to create the GitHub Release
 
+env:
+  # Pin the architecture/triplet everywhere so vcpkg, CMake, and the packaged
+  # artifact all agree on x64 and we never accidentally publish a 32-bit build.
+  VCPKG_DEFAULT_TRIPLET: x64-windows
+  VCPKG_TARGET_TRIPLET: x64-windows
+
 jobs:
   release:
     runs-on: windows-latest
@@ -44,7 +50,9 @@ jobs:
         shell: bash
         run: |
           tag="${{ github.ref_name }}"
-          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+          # Strict SemVer: numeric identifiers have no leading zeroes, so each of
+          # MAJOR/MINOR/PATCH is either 0 or a non-zero-led digit run.
+          if [[ ! "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Tag '$tag' is not a strict vX.Y.Z[-prerelease][+build] semver tag; refusing to release."
             exit 1
           fi
@@ -71,13 +79,15 @@ jobs:
 
       - name: Run vcpkg
         shell: pwsh
-        run: ${{ github.workspace }}/vcpkg/vcpkg.exe install
+        run: ${{ github.workspace }}/vcpkg/vcpkg.exe install --triplet x64-windows
 
       - name: Configure CMake
         run: >
           cmake
+          -A x64
           -D CMAKE_BUILD_TYPE=Release
           -D CMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+          -D VCPKG_TARGET_TRIPLET=x64-windows
           -D build_tests=ON
           -D BUILD_TESTING=ON
           -B ${{ steps.strings.outputs.build-output-dir }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,21 @@ jobs:
   release:
     runs-on: windows-latest
     steps:
+      - name: Validate tag is strict semver
+        # The on.push.tags glob can only require the vX.Y.Z *shape*; it can't
+        # enforce digits-only segments, so tags like v1foo.2.3 or v1.2.3.4 would
+        # still start this job. Reject anything that isn't strict
+        # vMAJOR.MINOR.PATCH (with an optional -prerelease / +build suffix) so we
+        # never publish an unintended release.
+        shell: bash
+        run: |
+          tag="${{ github.ref_name }}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Tag '$tag' is not a strict vX.Y.Z[-prerelease][+build] semver tag; refusing to release."
+            exit 1
+          fi
+          echo "Tag '$tag' accepted."
+
       - uses: actions/checkout@v5
         with:
           submodules: 'recursive'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,13 +82,15 @@ jobs:
         run: ${{ github.workspace }}/vcpkg/vcpkg.exe install --triplet x64-windows
 
       - name: Configure CMake
+        # The Visual Studio generator selected by -A x64 is multi-config, so the
+        # build type is chosen later via --config / --build-config / -C Release
+        # rather than CMAKE_BUILD_TYPE. Only BUILD_TESTING controls test builds
+        # in this project's CMake.
         run: >
           cmake
           -A x64
-          -D CMAKE_BUILD_TYPE=Release
           -D CMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
           -D VCPKG_TARGET_TRIPLET=x64-windows
-          -D build_tests=ON
           -D BUILD_TESTING=ON
           -B ${{ steps.strings.outputs.build-output-dir }}
           -S ${{ github.workspace }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,15 +11,20 @@ name: Release
 # project in Release, packages everything into a .zip with CPack, and publishes
 # a GitHub Release named after the tag with the .zip attached.
 #
-# The project's version comes from this same tag: the top-level CMakeLists.txt
-# runs `git describe --tags --match "v*"`, so the tag you push IS the version
-# that gets built. No version files to keep in sync.
+# The build version comes from this same tag: the top-level CMakeLists.txt runs
+# `git describe --tags --match "v*"` and extracts the numeric X.Y.Z. The release
+# is always named after the full tag, but note that any pre-release suffix
+# (e.g. the `-rc1` in v0.3.3-rc1) is NOT carried into the built PROJECT_VERSION,
+# which would be 0.3.3 in that example. There are no version files to keep in
+# sync.
 
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"      # e.g. v0.3.3
-      - "v[0-9]+.[0-9]+.[0-9]+-*"    # e.g. v0.3.3-rc1 (pre-releases)
+      # GitHub tag filters use glob (minimatch) syntax, not regex, so we cannot
+      # use `+` quantifiers here. "v[0-9]*" matches v followed by a digit then
+      # anything, covering both vX.Y.Z and pre-releases like vX.Y.Z-rc1.
+      - "v[0-9]*"
 
 permissions:
   contents: write   # needed to create the GitHub Release
@@ -44,12 +49,12 @@ jobs:
           echo "dist-dir=${{ github.workspace }}/dist" >> "$GITHUB_OUTPUT"
 
       - name: Bootstrap vcpkg
-        shell: bash
-        run: "${{ github.workspace }}/vcpkg/bootstrap-vcpkg.bat"
+        shell: pwsh
+        run: ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.bat
 
       - name: Run vcpkg
-        shell: bash
-        run: "${{ github.workspace }}/vcpkg/vcpkg" install
+        shell: pwsh
+        run: ${{ github.workspace }}/vcpkg/vcpkg.exe install
 
       - name: Configure CMake
         run: >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,3 +201,21 @@ install(
     DESTINATION
         ${SYSCONFIG_INSTALL_DIR}
 )
+
+# Packaging (CPack). This generates ${CMAKE_BINARY_DIR}/CPackConfig.cmake so that
+# `cpack` can build release artifacts in CI. Keep the generator list portable:
+# ZIP needs no extra tooling on the runner, unlike NSIS/DEB.
+set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_PACKAGE_VENDOR "Microsoft")
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "m C++ libraries")
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "${PROJECT_NAME}")
+set(CPACK_VERBATIM_VARIABLES ON)
+
+if(WIN32)
+    set(CPACK_GENERATOR "ZIP")
+else()
+    set(CPACK_GENERATOR "TGZ")
+endif()
+
+include(CPack)


### PR DESCRIPTION
Adds a tag-triggered release pipeline so we can publish GitHub Releases without any third-party actions.

## What it does
- New workflow `.github/workflows/release.yml` triggers on pushing a `vX.Y.Z` tag (and `vX.Y.Z-*` pre-release tags).
- It builds the project in Release with vcpkg, packages everything into a `.zip` via CPack, and publishes a GitHub Release named after the tag with the zip attached and auto-generated notes.
- Pre-release tags (e.g. `v0.3.3-rc1`) are automatically marked as pre-releases.

## How to cut a release
```
git tag v0.3.3
git push origin v0.3.3
```
The project version already comes from this same tag (top-level CMake `git describe --tags --match "v*"`), so the build version and release name always match.

## Notes
- Uses only first-party actions plus the built-in `gh` CLI with the default `GITHUB_TOKEN` — nothing needs org allow-listing.
- Wires `include(CPack)` into the top-level `CMakeLists.txt` (ZIP on Windows, TGZ elsewhere); the project previously never called it, so `cpack` had nothing to run.
- Uses the portable ZIP packager because GitHub's Windows runners don't ship NSIS. An NSIS installer can be added later if desired.
